### PR TITLE
Fix Placeables

### DIFF
--- a/SnapBuilder/Patch/Builder.cs
+++ b/SnapBuilder/Patch/Builder.cs
@@ -33,7 +33,12 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patch
 
             Transform aimTransform = Builder.GetAimTransform();
 
-            if (!SnapBuilder.TryGetSnappedHitPoint(ref hit, out Vector3 snappedHitPoint, out Vector3 snappedHitNormal, aimTransform))
+            if (!SnapBuilder.TryGetSnappedHitPoint(
+                Builder.placeLayerMask,
+                ref hit,
+                out Vector3 snappedHitPoint,
+                out Vector3 snappedHitNormal,
+                Builder.placeMaxDistance))
             {   // If there is no new hit, then the position we're snapping to isn't valid and we can just return false
                 // without setting the position or rotation and it will be treated as if no hit occurred
                 return false;
@@ -44,7 +49,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patch
 
             if (Builder.rotationEnabled)
             {   // New calculation of the rotation
-                rotation = SnapBuilder.CalculateRotation(ref Builder.additiveRotation, hit, snappedHitPoint, snappedHitNormal);
+                rotation = SnapBuilder.CalculateRotation(ref Builder.additiveRotation, hit, snappedHitPoint, snappedHitNormal, Builder.forceUpright);
             }
             else
             {   // Calculate rotation in the same manner as the original method

--- a/SnapBuilder/Patch/PlaceTool.cs
+++ b/SnapBuilder/Patch/PlaceTool.cs
@@ -27,7 +27,12 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patch
         public static bool Prefix(PlaceTool __instance)
         {
             if (__instance.usingPlayer == null || !SnapBuilder.Config.Snapping.Enabled)
+            {
+                Inventory.main.quickSlots.SetIgnoreHotkeyInput(false);
                 return true;
+            }
+
+            Inventory.main.quickSlots.SetIgnoreHotkeyInput(__instance.rotationEnabled);
 
             Transform aimTransform = Builder.GetAimTransform();
             RaycastHit hit;
@@ -35,9 +40,11 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patch
             Vector3 position = __instance.ghostModel.transform.position;
             Quaternion rotation = __instance.ghostModel.transform.rotation;
 
+            SnapBuilder.ApplyAdditiveRotation(ref __instance.additiveRotation, out var _);
+
             if (bHit)
             {
-                bHit = SnapBuilder.TryGetSnappedHitPoint(ref hit, out Vector3 snappedHitPoint, out Vector3 snappedHitNormal, aimTransform);
+                bHit = SnapBuilder.TryGetSnappedHitPoint(PlaceTool.placeLayerMask, ref hit, out Vector3 snappedHitPoint, out Vector3 snappedHitNormal);
 
                 if (bHit)
                 {
@@ -51,7 +58,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patch
 
                     if (__instance.rotationEnabled)
                     {   // New calculation of the rotation
-                        rotation = SnapBuilder.CalculateRotation(ref __instance.additiveRotation, hit, snappedHitPoint, snappedHitNormal);
+                        rotation = SnapBuilder.CalculateRotation(ref __instance.additiveRotation, hit, snappedHitPoint, snappedHitNormal, true);
                     }
                     else
                     {   // Calculate rotation in the same manner as the original method
@@ -88,7 +95,6 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patch
                 rotation = Quaternion.LookRotation(-aimTransform.forward, Vector3.up);
                 if (__instance.rotationEnabled)
                     rotation *= Quaternion.AngleAxis(__instance.additiveRotation, Vector3.up);
-                __instance.validPosition = false;
             }
 
             __instance.ghostModel.transform.position = position;
@@ -104,8 +110,6 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patch
             SubRoot currentSub = Player.main.GetCurrentSub();
 
             bool isInside = Player.main.IsInside();
-
-            bool inSub = bHit && hit.collider.gameObject.GetComponentInParent<SubRoot>() != null;
 
             if (bHit && hit.collider.gameObject.CompareTag("DenyBuilding"))
                 __instance.validPosition = false;
@@ -150,6 +154,16 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patch
             }
 
             return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(PlaceTool), nameof(PlaceTool.OnPlace))]
+    [HarmonyPatch(typeof(PlaceTool), nameof(PlaceTool.OnHolster))]
+    internal static class PlaceTool_OnPlace_OnHolster
+    {
+        public static void Postfix()
+        {
+            Inventory.main.quickSlots.SetIgnoreHotkeyInput(false);
         }
     }
 }


### PR DESCRIPTION
- Fixes the issue where placeable objects couldn't be placed with SnapBuilder enabled when the Builder hadn't been used yet.
- Fixes placeable objects cannot be rotated.

Closes #14 