### PR TITLE
Add toggle rotation button

### DIFF
--- a/SnapBuilder/Config.cs
+++ b/SnapBuilder/Config.cs
@@ -33,56 +33,71 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         [JsonIgnore]
         public Toggle FineRotation => fineRotation ??= new Toggle(FineRotationKey, FineRotationMode, false);
 
-        [Toggle(LabelLanguageId = "Options.SnappingEnabledByDefault"), OnChange(nameof(EnabledByDefaultChanged))]
+        [JsonIgnore]
+        private Toggle toggleRotation;
+        [JsonIgnore]
+        public Toggle ToggleRotation => toggleRotation ??= new Toggle(ToggleRotationKey, ToggleRotationMode, false);
+
+        [Toggle(LabelLanguageId = Lang.Option.DEFAULT_SNAPPING_ENABLED), OnChange(nameof(EnabledByDefaultChanged))]
         public bool EnabledByDefault { get; set; } = true;
         private void EnabledByDefaultChanged(ToggleChangedEventArgs e)
             => Snapping.EnabledByDefault = e.Value;
 
-        [Keybind(LabelLanguageId = "Options.ToggleSnappingKey"), OnChange(nameof(ToggleSnappingKeyChanged))]
+        [Keybind(LabelLanguageId = Lang.Option.TOGGLE_SNAPPING_KEY), OnChange(nameof(ToggleSnappingKeyChanged))]
         public KeyCode ToggleSnappingKey { get; set; } = KeyCode.Mouse2;
         private void ToggleSnappingKeyChanged(KeybindChangedEventArgs e)
             => Snapping.KeyCode = e.Key;
 
         [JsonConverter(typeof(StringEnumConverter))]
-        [Choice(LabelLanguageId = "Options.ToggleSnappingMode"), OnChange(nameof(ToggleSnappingModeChanged))]
+        [Choice(LabelLanguageId = Lang.Option.TOGGLE_SNAPPING_MODE), OnChange(nameof(ToggleSnappingModeChanged))]
         public Toggle.Mode ToggleSnappingMode { get; set; } = Toggle.Mode.Press;
         private void ToggleSnappingModeChanged(ChoiceChangedEventArgs e)
             => Snapping.KeyMode = (Toggle.Mode)e.Index;
 
-        [Keybind(LabelLanguageId = "Options.FineSnappingKey"), OnChange(nameof(FineSnappingKeyChanged))]
+        [Keybind(LabelLanguageId = Lang.Option.FINE_SNAPPING_KEY), OnChange(nameof(FineSnappingKeyChanged))]
         public KeyCode FineSnappingKey { get; set; } = KeyCode.LeftControl;
         private void FineSnappingKeyChanged(KeybindChangedEventArgs e)
             => FineSnapping.KeyCode = e.Key;
 
         [JsonConverter(typeof(StringEnumConverter))]
-        [Choice(LabelLanguageId = "Options.FineSnappingMode"), OnChange(nameof(FineSnappingModeChanged))]
+        [Choice(LabelLanguageId = Lang.Option.FINE_SNAPPING_MODE), OnChange(nameof(FineSnappingModeChanged))]
         public Toggle.Mode FineSnappingMode { get; set; } = Toggle.Mode.Hold;
         private void FineSnappingModeChanged(ChoiceChangedEventArgs e)
             => FineSnapping.KeyMode = (Toggle.Mode)e.Index;
 
-        [Keybind(LabelLanguageId = "Options.FineRotationKey"), OnChange(nameof(FineRotationKeyChanged))]
+        [Keybind(LabelLanguageId = Lang.Option.FINE_ROTATION_KEY), OnChange(nameof(FineRotationKeyChanged))]
         public KeyCode FineRotationKey { get; set; } = KeyCode.LeftAlt;
         private void FineRotationKeyChanged(KeybindChangedEventArgs e)
             => FineRotation.KeyCode = e.Key;
 
         [JsonConverter(typeof(StringEnumConverter))]
-        [Choice(LabelLanguageId = "Options.FineRotationMode"), OnChange(nameof(FineRotationModeChanged))]
+        [Choice(LabelLanguageId = Lang.Option.FINE_ROTATION_MODE), OnChange(nameof(FineRotationModeChanged))]
         public Toggle.Mode FineRotationMode { get; set; } = Toggle.Mode.Hold;
         private void FineRotationModeChanged(ChoiceChangedEventArgs e)
             => FineRotation.KeyMode = (Toggle.Mode)e.Index;
 
+        [Keybind(LabelLanguageId = Lang.Option.TOGGLE_ROTATION_KEY), OnChange(nameof(EnableRotationKeyChanged))]
+        public KeyCode ToggleRotationKey { get; set; } = KeyCode.Q;
+        private void EnableRotationKeyChanged(KeybindChangedEventArgs e)
+            => ToggleRotation.KeyCode = e.Key;
+
+        [Choice(LabelLanguageId = Lang.Option.TOGGLE_ROTATION_MODE), OnChange(nameof(EnableRotationModeChanged))]
+        public Toggle.Mode ToggleRotationMode { get; set; } = Toggle.Mode.Hold;
+        private void EnableRotationModeChanged(ChoiceChangedEventArgs e)
+            => ToggleRotation.KeyMode = (Toggle.Mode)e.Index;
+
         [JsonConverter(typeof(FloatConverter), 2)]
-        [Slider(0.01f, 1, LabelLanguageId = "Options.SnapRounding", Step = 0.01f, Format = "{0:##0%}", DefaultValue = 0.5f)]
+        [Slider(0.01f, 1, LabelLanguageId = Lang.Option.SNAP_ROUNDING, Step = 0.01f, Format = "{0:##0%}", DefaultValue = 0.5f)]
         public float SnapRounding { get; set; } = 0.5f;
 
         [JsonConverter(typeof(FloatConverter), 2)]
-        [Slider(0.01f, 1, LabelLanguageId = "Options.FineSnapRounding", Step = 0.01f, Format = "{0:##0%}", DefaultValue = 0.2f)]
+        [Slider(0.01f, 1, LabelLanguageId = Lang.Option.FINE_SNAP_ROUNDING, Step = 0.01f, Format = "{0:##0%}", DefaultValue = 0.2f)]
         public float FineSnapRounding { get; set; } = 0.2f;
 
-        [Slider(0, 90, LabelLanguageId = "Options.RotationRounding", DefaultValue = 45)]
+        [Slider(0, 90, LabelLanguageId = Lang.Option.ROTATION_ROUNDING, DefaultValue = 45)]
         public int RotationRounding { get; set; } = 45;
 
-        [Slider(0, 45, LabelLanguageId = "Options.FineRotationRounding", DefaultValue = 5)]
+        [Slider(0, 45, LabelLanguageId = Lang.Option.FINE_ROTATION_ROUNDING, DefaultValue = 5)]
         public int FineRotationRounding { get; set; } = 5;
 
         public bool HasUpgraded = false;
@@ -97,6 +112,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             Snapping.Reset();
             FineSnapping.Reset();
             FineRotation.Reset();
+            ToggleRotation.Reset();
         }
 
         private void Upgrade()

--- a/SnapBuilder/Lang.cs
+++ b/SnapBuilder/Lang.cs
@@ -1,0 +1,31 @@
+﻿namespace Straitjacket.Subnautica.Mods.SnapBuilder
+{
+    internal static class Lang
+    {
+        internal static class Hint
+        {
+            public const string TOGGLE_SNAPPING = "GhostToggleSnappingHint";
+            public const string TOGGLE_FINE_SNAPPING = "GhostToggleFineSnappingHint";
+            public const string TOGGLE_ROTATION = "GhostToggleRotationHint";
+            public const string TOGGLE_FINE_ROTATION = "GhostToggleFineRotationHint";
+            public const string HOLSTER_ITEM = "GhostHolsterItemHint";
+        }
+
+        internal static class Option
+        {
+            public const string DEFAULT_SNAPPING_ENABLED = "Options.SnappingEnabledByDefault";
+            public const string TOGGLE_SNAPPING_KEY = "Options.ToggleSnappingKey";
+            public const string TOGGLE_SNAPPING_MODE = "Options.ToggleSnappingMode";
+            public const string FINE_SNAPPING_KEY = "Options.FineSnappingKey";
+            public const string FINE_SNAPPING_MODE = "Options.FineSnappingMode";
+            public const string FINE_ROTATION_KEY = "Options.FineRotationKey";
+            public const string FINE_ROTATION_MODE = "Options.FineRotationMode";
+            public const string TOGGLE_ROTATION_KEY = "Options.ToggleRotationKey";
+            public const string TOGGLE_ROTATION_MODE = "Options.ToggleRotationMode";
+            public const string SNAP_ROUNDING = "Options.SnapRounding";
+            public const string FINE_SNAP_ROUNDING = "Options.FineSnapRounding";
+            public const string ROTATION_ROUNDING = "Options.RotationRounding";
+            public const string FINE_ROTATION_ROUNDING = "Options.FineRotationRounding";
+        }
+    }
+}

--- a/SnapBuilder/Patches/BuilderPatch.cs
+++ b/SnapBuilder/Patches/BuilderPatch.cs
@@ -21,7 +21,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
         [HarmonyPostfix]
         public static void BeginPostfix(bool __state)
         {
-            SnapBuilder.ShowRotationHint(__state && Builder.rotationEnabled);
+            SnapBuilder.ShowToggleFineRotationHint(__state && Builder.rotationEnabled);
         }
         #endregion
 

--- a/SnapBuilder/Patches/PlaceToolPatch.cs
+++ b/SnapBuilder/Patches/PlaceToolPatch.cs
@@ -21,7 +21,9 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
         [HarmonyPostfix]
         public static void Postfix(PlaceTool __instance, bool __state)
         {
-            SnapBuilder.ShowRotationHint(__state && __instance.rotationEnabled);
+            SnapBuilder.ShowToggleRotationHint(__state && __instance.rotationEnabled);
+            SnapBuilder.ShowToggleFineRotationHint(__state && __instance.rotationEnabled);
+            SnapBuilder.ShowHolsterHint(__state && __instance.rotationEnabled);
         }
         #endregion
 
@@ -36,7 +38,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
                 return true;
             }
 
-            Inventory.main.quickSlots.SetIgnoreHotkeyInput(__instance.rotationEnabled);
+            Inventory.main.quickSlots.SetIgnoreHotkeyInput(__instance.rotationEnabled && SnapBuilder.Config.ToggleRotation.Enabled);
 
             Transform aimTransform = Builder.GetAimTransform();
             RaycastHit hit;

--- a/SnapBuilder/Properties/AssemblyInfo.cs
+++ b/SnapBuilder/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.4.1")]
-[assembly: AssemblyFileVersion("1.3.4.1")]
+[assembly: AssemblyVersion("1.3.5.0")]
+[assembly: AssemblyFileVersion("1.3.5.0")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -42,7 +42,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             Logger.LogInfo($"Initialised in {stopwatch.ElapsedMilliseconds}ms.");
         }
 
-        public static void ApplyHarmonyPatches()
+        private static void ApplyHarmonyPatches()
         {
             var stopwatch = Stopwatch.StartNew();
 
@@ -58,20 +58,24 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         {
             foreach (var entry in new Dictionary<string, string>()
             {
-                ["GhostToggleSnappingHint"] = "Toggle snapping",
-                ["GhostToggleFineSnappingHint"] = "Toggle fine snapping",
-                ["GhostToggleFineRotationHint"] = "Toggle fine rotation",
-                ["Options.SnappingEnabledByDefault"] = "Snapping enabled by default",
-                ["Options.ToggleSnappingKey"] = "Toggle snapping button",
-                ["Options.ToggleSnappingMode"] = "Toggle snapping mode",
-                ["Options.FineSnappingKey"] = "Fine snapping button",
-                ["Options.FineSnappingMode"] = "Fine snapping mode",
-                ["Options.FineRotationKey"] = "Fine rotation button",
-                ["Options.FineRotationMode"] = "Fine rotation mode",
-                ["Options.SnapRounding"] = "Snap rounding",
-                ["Options.FineSnapRounding"] = "Fine snap rounding",
-                ["Options.RotationRounding"] = "Rotation rounding (degrees)",
-                ["Options.FineRotationRounding"] = "Fine rotation rounding (degrees)"
+                [Lang.Hint.TOGGLE_SNAPPING] = "Toggle snapping",
+                [Lang.Hint.TOGGLE_FINE_SNAPPING] = "Toggle fine snapping",
+                [Lang.Hint.TOGGLE_ROTATION] = "Toggle rotation",
+                [Lang.Hint.TOGGLE_FINE_ROTATION] = "Toggle fine rotation",
+                [Lang.Hint.HOLSTER_ITEM] = "Holster item",
+                [Lang.Option.DEFAULT_SNAPPING_ENABLED] = "Snapping enabled by default",
+                [Lang.Option.TOGGLE_SNAPPING_KEY] = "Toggle snapping button",
+                [Lang.Option.TOGGLE_SNAPPING_MODE] = "Toggle snapping mode",
+                [Lang.Option.FINE_SNAPPING_KEY] = "Fine snapping button",
+                [Lang.Option.FINE_SNAPPING_MODE] = "Fine snapping mode",
+                [Lang.Option.FINE_ROTATION_KEY] = "Fine rotation button",
+                [Lang.Option.FINE_ROTATION_MODE] = "Fine rotation mode",
+                [Lang.Option.TOGGLE_ROTATION_KEY] = "Toggle rotation button (for placeable items)",
+                [Lang.Option.TOGGLE_ROTATION_MODE] = "Toggle rotation mode (for placeable items)",
+                [Lang.Option.SNAP_ROUNDING] = "Snap rounding",
+                [Lang.Option.FINE_SNAP_ROUNDING] = "Fine snap rounding",
+                [Lang.Option.ROTATION_ROUNDING] = "Rotation rounding (degrees)",
+                [Lang.Option.FINE_ROTATION_ROUNDING] = "Fine rotation rounding (degrees)"
             })
             {
                 SetLanguage(entry.Key, entry.Value);
@@ -110,22 +114,40 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
 
         public static void ShowSnappingHint(bool shouldShow = true)
         {
-            if (shouldShow)
-            {
-                ErrorMessage.AddError($"{GetLanguage("GhostToggleSnappingHint")}" +
-                        $" ({FormatButton(Config.Snapping)})");
-                ErrorMessage.AddError($"{GetLanguage("GhostToggleFineSnappingHint")}" +
-                    $" ({FormatButton(Config.FineSnapping)})");
-            }
+            if (!shouldShow)
+                return;
+
+            ErrorMessage.AddError(GetLanguage(Lang.Hint.TOGGLE_SNAPPING) +
+                    $" ({FormatButton(Config.Snapping)})");
+            ErrorMessage.AddError(GetLanguage(Lang.Hint.TOGGLE_FINE_SNAPPING) +
+                $" ({FormatButton(Config.FineSnapping)})");
         }
 
-        public static void ShowRotationHint(bool shouldShow = true)
+        public static void ShowToggleFineRotationHint(bool shouldShow = true)
         {
-            if (shouldShow)
-            {
-                ErrorMessage.AddError($"{GetLanguage("GhostToggleFineRotationHint")}" +
-                    $" ({FormatButton(Config.FineRotation)})");
-            }
+            if (!shouldShow)
+                return;
+
+            ErrorMessage.AddError(GetLanguage(Lang.Hint.TOGGLE_FINE_ROTATION) +
+                $" ({FormatButton(Config.FineRotation)})");
+        }
+
+        public static void ShowToggleRotationHint(bool shouldShow = true)
+        {
+            if (!shouldShow)
+                return;
+
+            ErrorMessage.AddError(GetLanguage(Lang.Hint.TOGGLE_ROTATION) +
+                $" ({FormatButton(Config.ToggleRotation)})");
+        }
+
+        public static void ShowHolsterHint(bool shouldShow = true)
+        {
+            if (!shouldShow)
+                return;
+
+            ErrorMessage.AddError(GetLanguage(Lang.Hint.HOLSTER_ITEM) +
+                $" ({uGUI.FormatButton(GameInput.Button.Exit, true, ", ", false)})");
         }
 
         public static bool TryGetSnappedHitPoint(LayerMask layerMask, ref RaycastHit hit,

--- a/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
+++ b/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">SUBNAUTICA</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{90B8CFBB-759D-4E62-B923-05C2FEFE5CB3}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -62,7 +61,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>$(GameDir)\BepInEx\core\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
@@ -80,7 +79,6 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="UnityEngine">
       <HintPath>$(ManagedDir)\UnityEngine.dll</HintPath>
       <Private>False</Private>
@@ -96,6 +94,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config.cs" />
+    <Compile Include="Lang.cs" />
     <Compile Include="Patches\BuilderPatch.cs" />
     <Compile Include="Patches\PlaceToolPatch.cs" />
     <Compile Include="Main.cs" />

--- a/SnapBuilder/mod_BELOWZERO.json
+++ b/SnapBuilder/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.4.1",
+    "Version": "1.3.5",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/SnapBuilder/mod_SUBNAUTICA.json
+++ b/SnapBuilder/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.4.1",
+    "Version": "1.3.5",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
- To rotate placeable items, it is now required to toggle rotation via a customisable keybind. This should address user confusion where they could no longer switch items when holding a placeable item which can be rotated.
- Hints for toggling rotation and holstering the item are now displayed.