### PR TITLE
Fix glitchy BelowZero snapping

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "SMLHelper.Language"]
 	path = SMLHelper.Language
 	url = https://github.com/tobeyStraitjacket/SMLHelper.Language
+[submodule "Straitjacket.ExtensionMethods.UnityEngine"]
+	path = Straitjacket.ExtensionMethods.UnityEngine
+	url = https://github.com/tobeyStraitjacket/Straitjacket.ExtensionMethods.UnityEngine

--- a/SnapBuilder.sln
+++ b/SnapBuilder.sln
@@ -11,13 +11,17 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "BepInEx.Subnautica.Logger",
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "SMLHelper.Language", "SMLHelper.Language\SMLHelper.Language\SMLHelper.Language.shproj", "{AD133C9E-A9A1-4DBC-BD93-7149D32CB98A}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Straitjacket.ExtensionMethods.UnityEngine", "Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine.shproj", "{91E30B75-0933-43CC-98FF-7C9DCCA7F849}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Toggle\Toggle\Toggle.projitems*{2e9fec3f-6690-46e8-b676-9778d4b1292a}*SharedItemsImports = 13
 		BepInEx.Logger\Logger\Logger.projitems*{32f6ed8c-0f9a-409d-a404-ee068789c72f}*SharedItemsImports = 13
 		BepInEx.Logger\Logger\Logger.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
 		SMLHelper.Language\SMLHelper.Language\Language.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
+		Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
 		Toggle\Toggle\Toggle.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
+		Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine.projitems*{91e30b75-0933-43cc-98ff-7c9dcca7f849}*SharedItemsImports = 13
 		SMLHelper.Language\SMLHelper.Language\Language.projitems*{ad133c9e-a9a1-4dbc-bd93-7149d32cb98a}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/SnapBuilder/Patches/BuilderPatch.cs
+++ b/SnapBuilder/Patches/BuilderPatch.cs
@@ -28,7 +28,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
         #region Builder.SetPlaceOnSurface
         [HarmonyPatch(typeof(Builder), nameof(Builder.SetPlaceOnSurface))]
         [HarmonyPrefix]
-        public static bool SetPlaceOnSurfacePrefix(RaycastHit hit, ref Vector3 position, ref Quaternion rotation)
+        public static bool SetPlaceOnSurfacePrefix(ref Vector3 position, ref Quaternion rotation)
         {
             if (!SnapBuilder.Config.Snapping.Enabled)
             {
@@ -39,7 +39,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 
             if (!SnapBuilder.TryGetSnappedHitPoint(
                 Builder.placeLayerMask,
-                ref hit,
+                out RaycastHit hit,
                 out Vector3 snappedHitPoint,
                 out Vector3 snappedHitNormal,
                 Builder.placeMaxDistance))

--- a/SnapBuilder/Patches/PlaceToolPatch.cs
+++ b/SnapBuilder/Patches/PlaceToolPatch.cs
@@ -50,7 +50,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 
             if (bHit)
             {
-                bHit = SnapBuilder.TryGetSnappedHitPoint(PlaceTool.placeLayerMask, ref hit, out Vector3 snappedHitPoint, out Vector3 snappedHitNormal);
+                bHit = SnapBuilder.TryGetSnappedHitPoint(PlaceTool.placeLayerMask, out hit, out Vector3 snappedHitPoint, out Vector3 snappedHitNormal);
 
                 if (bHit)
                 {

--- a/SnapBuilder/Properties/AssemblyInfo.cs
+++ b/SnapBuilder/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.6.0")]
-[assembly: AssemblyFileVersion("1.3.6.0")]
+[assembly: AssemblyVersion("1.3.7.0")]
+[assembly: AssemblyFileVersion("1.3.7.0")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -140,8 +140,9 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 return false;
             }
 
-            Vector3 localPoint = hit.transform.parent.InverseTransformPoint(hit.point); // Get the hit point localised relative to the hit transform
-            Vector3 localNormal = hit.transform.parent.InverseTransformDirection(hit.normal).normalized; // Get the hit normal localised to the hit transform
+            Transform hitTransform = hit.transform.parent ?? hit.transform;
+            Vector3 localPoint = hitTransform.InverseTransformPoint(hit.point); // Get the hit point localised relative to the hit transform
+            Vector3 localNormal = hitTransform.parent.InverseTransformDirection(hit.normal).normalized; // Get the hit normal localised to the hit transform
 
             // Set the localised normal to absolute values for comparison
             localNormal.x = Mathf.Abs(localNormal.x);
@@ -168,7 +169,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
 
             // Now, perform a new raycast so that we can get the normal of the new position
             if (!Physics.Raycast(aimTransform.position,
-                                 hit.transform.parent.TransformPoint(localPoint) - aimTransform.position, // direction from the aim transform to the new world space position of the rounded/snapped position
+                                 hitTransform.TransformPoint(localPoint) - aimTransform.position, // direction from the aim transform to the new world space position of the rounded/snapped position
                                  out hit, // overwrite hit
                                  maxDistance,
                                  layerMask,

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -125,9 +125,10 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             out Vector3 snappedHitPoint, out Vector3 snappedHitNormal, float maxDistance = 5f)
         {
             Transform aimTransform = Builder.GetAimTransform();
-            aimTransform = aimTransform.FindAncestor("camOffset").parent;
+            aimTransform = aimTransform.FindAncestor("camOffset").parent; // Use a non-moving parent of the aimTransform instead, to counteract the movement of the camera
             aimTransform ??= aimTransform.FindAncestor(transform => !transform.position.Equals(aimTransform.position)) ?? Builder.GetAimTransform();
 
+            // Get a new hit based on our preferred aimTransform
             if (!Physics.Raycast(aimTransform.position,
                                  Builder.GetAimTransform().forward,
                                  out hit,
@@ -140,7 +141,8 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 return false;
             }
 
-            Transform hitTransform = hit.transform.parent ?? hit.transform;
+            Transform hitTransform = hit.transform.parent ?? hit.transform; // Where possible, use the transform of the parent as this should be a better reference point for localisation
+                                                                            // (especially useful inside a base)
             Vector3 localPoint = hitTransform.InverseTransformPoint(hit.point); // Get the hit point localised relative to the hit transform
             Vector3 localNormal = hitTransform.parent.InverseTransformDirection(hit.normal).normalized; // Get the hit normal localised to the hit transform
 

--- a/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
+++ b/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
@@ -109,6 +109,7 @@
   <Import Project="..\Toggle\Toggle\Toggle.projitems" Label="Shared" />
   <Import Project="..\BepInEx.Logger\Logger\Logger.projitems" Label="Shared" />
   <Import Project="..\SMLHelper.Language\SMLHelper.Language\Language.projitems" Label="Shared" />
+  <Import Project="..\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>echo f | xcopy "$(ProjectDir)mod_$(ConfigurationName).json" "$(TargetDir)$(SolutionName)\mod.json" /y

--- a/SnapBuilder/mod_BELOWZERO.json
+++ b/SnapBuilder/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.6",
+    "Version": "1.3.7",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/SnapBuilder/mod_SUBNAUTICA.json
+++ b/SnapBuilder/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.6",
+    "Version": "1.3.7",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
# Changes in this pull request
- We now ignore the `RaycastHit` that was being generated from the `Builder.GetAimTransform()` as this is based on a camera that is constantly moving, and causing issues when snapping. Instead, we generate a new `RaycastHit` using the position of a parent of the aim transform that is not moving.
- Also generally improves the snapping inside a base by using the parent of the hit as a reference point for localisation where possible