### PR TITLE
Bugfix: Fix Outdoor Snaps

### DIFF
--- a/SnapBuilder/Properties/AssemblyInfo.cs
+++ b/SnapBuilder/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.7.0")]
-[assembly: AssemblyFileVersion("1.3.7.0")]
+[assembly: AssemblyVersion("1.3.7.1")]
+[assembly: AssemblyFileVersion("1.3.7.1")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -150,7 +150,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             };
 
             Vector3 localPoint = hitTransform.InverseTransformPoint(hit.point); // Get the hit point localised relative to the hit transform
-            Vector3 localNormal = hitTransform.parent.InverseTransformDirection(hit.normal).normalized; // Get the hit normal localised to the hit transform
+            Vector3 localNormal = (hitTransform.parent ?? hitTransform).InverseTransformDirection(hit.normal).normalized; // Get the hit normal localised to the hit transform
 
             // Set the localised normal to absolute values for comparison
             localNormal.x = Mathf.Abs(localNormal.x);

--- a/SnapBuilder/mod_BELOWZERO.json
+++ b/SnapBuilder/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7",
+    "Version": "1.3.7.1",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/SnapBuilder/mod_SUBNAUTICA.json
+++ b/SnapBuilder/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7",
+    "Version": "1.3.7.1",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
Fixes a bug where since 1.3.7, snapping to the ground outdoors has been broken due to the hit.transform not having a parent.