### PR TITLE
Improve wonky rotations

### DIFF
--- a/SnapBuilder/Properties/AssemblyInfo.cs
+++ b/SnapBuilder/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.7.1")]
-[assembly: AssemblyFileVersion("1.3.7.1")]
+[assembly: AssemblyVersion("1.3.8.0")]
+[assembly: AssemblyFileVersion("1.3.8.0")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -311,15 +311,24 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 empty.transform.forward = hitTransform.forward; // Set the parent transform's forward to match the forward of the hit.transform
             }
 
-            if (!forceUpright)
-            {   // Rotate the parent transform so that it's Y axis is aligned with the hit.normal, but only when it isn't forced upright
+            // In the case that the forward of the hitTransform isn't completely flat and our hit is from a MeshCollider, we are probably working with some 
+            // outside piece of rock or something weird, so just use the global Vector3.forward and set the up to match the hit normal
+            if (hit.collider is MeshCollider meshCollider && meshCollider.sharedMesh is Mesh && hit.transform.forward.y != 0 && !Player.main.IsInsideWalkable())
+            {
+                empty.transform.forward = Vector3.forward;
+                empty.transform.up = snappedHitNormal;
+            }
+            else if (!forceUpright)
+            {   // Rotate the parent transform so that its Y axis is aligned with the hit.normal, but only when it isn't forced upright
                 empty.transform.rotation = Quaternion.FromToRotation(Vector3.up, snappedHitNormal) * empty.transform.rotation;
             }
 
-            child.transform.LookAt(Player.main.transform); // Rotate the child transform to look at the player (so that the object will face the player by default, as in the original)
+            // Rotate the child transform to look at the player (so that the object will face the player by default, as in the original)
+            child.transform.LookAt(Player.main.transform);
+
+            // Round/snap the Y axis of the child transform's local rotation based on the user's rotation factor, after adding the additiveRotation
             child.transform.localEulerAngles
-                = new Vector3(0, RoundToNearest(child.transform.localEulerAngles.y + additiveRotation, rotationFactor) % 360,
-                0); // Round/snap the Y axis of the child transform's local rotation based on the user's rotation factor, after adding the additiveRotation
+                = new Vector3(0, RoundToNearest(child.transform.localEulerAngles.y + additiveRotation, rotationFactor) % 360, 0);
 
             Quaternion rotation = child.transform.rotation; // Our final rotation
 

--- a/SnapBuilder/mod_BELOWZERO.json
+++ b/SnapBuilder/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7.1",
+    "Version": "1.3.8",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/SnapBuilder/mod_SUBNAUTICA.json
+++ b/SnapBuilder/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7.1",
+    "Version": "1.3.8",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
- Improves the rotations of objects when placed on an object where the hit.transform.forward is not perfectly horizontal
- Also improves the global facing direction of objects that are placed on the external ground to all be aligned with Vector3.forward instead of the hit.transform.forward, for a more uniform global forward direction