### PR TITLE
Remove obsolete hoverpad test

### DIFF
--- a/SnapBuilder/Properties/AssemblyInfo.cs
+++ b/SnapBuilder/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.7.2")]
-[assembly: AssemblyFileVersion("1.3.7.2")]
+[assembly: AssemblyVersion("1.3.7.3")]
+[assembly: AssemblyFileVersion("1.3.7.3")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -291,25 +291,12 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         {
             ApplyAdditiveRotation(ref additiveRotation, out float rotationFactor);
 
-            Transform hitTransform = hit.transform;
-            if (!Player.main.IsInsideWalkable())
-            {   // If the player is outside, get the root transform if there is one, otherwise default to the original
-                hitTransform = UWE.Utils.GetEntityRoot(hit.transform.gameObject)?.transform ?? hit.transform;
-            }
-
             // Instantiate empty game objects for applying rotations
             GameObject empty = new GameObject();
             GameObject child = new GameObject();
             child.transform.parent = empty.transform; // parent the child to the empty
             child.transform.localPosition = Vector3.zero; // Make sure the child's local position is Vector3.zero
             empty.transform.position = snappedHitPoint; // Set the parent transform's position to our chosen position
-
-#if BELOWZERO
-            if (Builder.constructableTechType != TechType.Hoverpad) // Stupid hoverpad, working differently to everything else in the game...
-#endif
-            {
-                empty.transform.forward = hitTransform.forward; // Set the parent transform's forward to match the forward of the hit.transform
-            }
 
             // In the case that the forward of the hitTransform isn't completely flat and our hit is from a MeshCollider, we are probably working with some 
             // outside piece of rock or something weird, so just use the global Vector3.forward and set the up to match the hit normal

--- a/SnapBuilder/mod_BELOWZERO.json
+++ b/SnapBuilder/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7.2",
+    "Version": "1.3.7.3",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/SnapBuilder/mod_SUBNAUTICA.json
+++ b/SnapBuilder/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7.2",
+    "Version": "1.3.7.3",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
Since at least SnapBuilder 1.3.7.2, it is no longer necessary to incorporate logic based on whether the user is attempting to place a Snowfox pad, so we can remove this code.