### PR TITLE
Migrate snapping code to Builder.GetAimTransform

### DIFF
--- a/SnapBuilder/Patches/BuilderPatch.cs
+++ b/SnapBuilder/Patches/BuilderPatch.cs
@@ -25,75 +25,21 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
         }
         #endregion
 
+        #region Builder.GetAimTransform
+        [HarmonyPatch(typeof(Builder), nameof(Builder.GetAimTransform))]
+        [HarmonyPostfix]
+        public static Transform GetAimTransformPostfix(Transform _) => SnapBuilder.GetAimTransform();
+        #endregion
+
         #region Builder.SetPlaceOnSurface
         [HarmonyPatch(typeof(Builder), nameof(Builder.SetPlaceOnSurface))]
-        [HarmonyPrefix]
-        public static bool SetPlaceOnSurfacePrefix(ref Vector3 position, ref Quaternion rotation)
+        [HarmonyPostfix]
+        public static void SetPlaceOnSurfacePostfix(RaycastHit hit, ref Quaternion rotation)
         {
-            if (!SnapBuilder.Config.Snapping.Enabled)
+            if (SnapBuilder.Config.Snapping.Enabled && Builder.rotationEnabled)
             {
-                return true; // Pass to the original function if SnapBuilder is disabled
+                rotation = SnapBuilder.CalculateRotation(ref Builder.additiveRotation, hit, Builder.forceUpright);
             }
-
-            Transform aimTransform = Builder.GetAimTransform();
-
-            if (!SnapBuilder.TryGetSnappedHitPoint(
-                Builder.placeLayerMask,
-                out RaycastHit hit,
-                out Vector3 snappedHitPoint,
-                out Vector3 snappedHitNormal,
-                Builder.placeMaxDistance))
-            {   // If there is no new hit, then the position we're snapping to isn't valid and we can just return false
-                // without setting the position or rotation and it will be treated as if no hit occurred
-                return false;
-            }
-
-            // Set the position equal to the new hit point
-            position = snappedHitPoint;
-
-            if (Builder.rotationEnabled)
-            {   // New calculation of the rotation
-                rotation = SnapBuilder.CalculateRotation(ref Builder.additiveRotation, hit, snappedHitPoint, snappedHitNormal, Builder.forceUpright);
-            }
-            else
-            {   // Calculate rotation in the same manner as the original method
-                Vector3 vector = Vector3.forward;
-                Vector3 vector2 = Vector3.up;
-
-                if (Builder.forceUpright)
-                {
-                    vector = -aimTransform.forward;
-                    vector.y = 0f;
-                    vector.Normalize();
-                    vector2 = Vector3.up;
-                }
-                else
-                {
-                    switch (Builder.GetSurfaceType(snappedHitNormal))
-                    {
-                        case SurfaceType.Ground:
-                            vector2 = snappedHitNormal;
-                            vector = -aimTransform.forward;
-                            vector.y -= Vector3.Dot(vector, vector2);
-                            vector.Normalize();
-                            break;
-                        case SurfaceType.Wall:
-                            vector = snappedHitNormal;
-                            vector2 = Vector3.up;
-                            break;
-                        case SurfaceType.Ceiling:
-                            vector = snappedHitNormal;
-                            vector2 = -aimTransform.forward;
-                            vector2.y -= Vector3.Dot(vector2, vector);
-                            vector2.Normalize();
-                            break;
-                    }
-                }
-
-                rotation = Quaternion.LookRotation(vector, vector2);
-            }
-
-            return false; // Do not run the original method
         }
         #endregion
     }

--- a/SnapBuilder/Patches/PlaceToolPatch.cs
+++ b/SnapBuilder/Patches/PlaceToolPatch.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using UnityEngine;
 
 namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 {
@@ -29,137 +28,17 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 
         #region PlaceTool.LateUpdate
         [HarmonyPatch(typeof(PlaceTool), nameof(PlaceTool.LateUpdate))]
-        [HarmonyPrefix]
-        public static bool LateUpdatePrefix(PlaceTool __instance)
+        [HarmonyPostfix]
+        public static void LateUpdatePostfix(PlaceTool __instance)
         {
             if (__instance.usingPlayer == null || !SnapBuilder.Config.Snapping.Enabled)
             {
                 Inventory.main.quickSlots.SetIgnoreHotkeyInput(false);
-                return true;
-            }
-
-            Inventory.main.quickSlots.SetIgnoreHotkeyInput(__instance.rotationEnabled && SnapBuilder.Config.ToggleRotation.Enabled);
-
-            Transform aimTransform = Builder.GetAimTransform();
-            RaycastHit hit;
-            bool bHit = Physics.Raycast(aimTransform.position, aimTransform.forward, out hit, 5f, PlaceTool.placeLayerMask, QueryTriggerInteraction.Ignore);
-            Vector3 position = __instance.ghostModel.transform.position;
-            Quaternion rotation = __instance.ghostModel.transform.rotation;
-
-            SnapBuilder.ApplyAdditiveRotation(ref __instance.additiveRotation, out var _);
-
-            if (bHit)
-            {
-                bHit = SnapBuilder.TryGetSnappedHitPoint(PlaceTool.placeLayerMask, out hit, out Vector3 snappedHitPoint, out Vector3 snappedHitNormal);
-
-                if (bHit)
-                {
-                    position = snappedHitPoint;
-
-                    PlaceTool.SurfaceType surfaceType = PlaceTool.SurfaceType.Floor;
-                    if (Mathf.Abs(hit.normal.y) < 0.3f)
-                        surfaceType = PlaceTool.SurfaceType.Wall;
-                    else if (hit.normal.y < 0f)
-                        surfaceType = PlaceTool.SurfaceType.Ceiling;
-
-                    if (__instance.rotationEnabled)
-                    {   // New calculation of the rotation
-                        rotation = SnapBuilder.CalculateRotation(ref __instance.additiveRotation, hit, snappedHitPoint, snappedHitNormal, true);
-                    }
-                    else
-                    {   // Calculate rotation in the same manner as the original method
-                        Vector3 forward;
-
-                        if (__instance.alignWithSurface || surfaceType == PlaceTool.SurfaceType.Wall)
-                            forward = hit.normal;
-                        else
-                            forward = new Vector3(-aimTransform.forward.x, 0f, -aimTransform.forward.z).normalized;
-
-                        rotation = Quaternion.LookRotation(forward, Vector3.up);
-                        if (__instance.rotationEnabled)
-                            rotation *= Quaternion.AngleAxis(__instance.additiveRotation, Vector3.up);
-                    }
-
-                    switch (surfaceType)
-                    {
-                        case PlaceTool.SurfaceType.Floor:
-                            __instance.validPosition = __instance.allowedOnGround;
-                            break;
-                        case PlaceTool.SurfaceType.Wall:
-                            __instance.validPosition = __instance.allowedOnWalls;
-                            break;
-                        case PlaceTool.SurfaceType.Ceiling:
-                            __instance.validPosition = __instance.allowedOnCeiling;
-                            break;
-                    }
-                }
-            }
-
-            if (!bHit)
-            {   // If there is no new hit, then the position we're snapping to isn't valid
-                position = aimTransform.position + aimTransform.forward * 1.5f;
-                rotation = Quaternion.LookRotation(-aimTransform.forward, Vector3.up);
-                if (__instance.rotationEnabled)
-                    rotation *= Quaternion.AngleAxis(__instance.additiveRotation, Vector3.up);
-            }
-
-            __instance.ghostModel.transform.position = position;
-            __instance.ghostModel.transform.rotation = rotation;
-
-            if (bHit)
-            {
-                Rigidbody componentInParent = hit.collider.gameObject.GetComponentInParent<Rigidbody>();
-                __instance.validPosition = (__instance.validPosition &&
-                    (componentInParent == null || componentInParent.isKinematic || __instance.allowedOnRigidBody));
-            }
-
-            SubRoot currentSub = Player.main.GetCurrentSub();
-
-            bool isInside = Player.main.IsInsideWalkable();
-
-            if (bHit && hit.collider.gameObject.CompareTag("DenyBuilding"))
-                __instance.validPosition = false;
-
-#if BELOWZERO
-            if (!__instance.allowedUnderwater && hit.point.y < 0)
-                __instance.validPosition = false;
-#endif
-
-            if (bHit && ((__instance.allowedInBase && isInside) || (__instance.allowedOutside && !isInside)))
-            {
-                GameObject root = UWE.Utils.GetEntityRoot(hit.collider.gameObject);
-                if (!root)
-                {
-                    SceneObjectIdentifier identifier = hit.collider.GetComponentInParent<SceneObjectIdentifier>();
-                    if (identifier)
-                    {
-                        root = identifier.gameObject;
-                    }
-                    else
-                    {
-                        root = hit.collider.gameObject;
-                    }
-                }
-
-                if (currentSub == null)
-                    __instance.validPosition &= Builder.ValidateOutdoor(root);
-
-                if (!__instance.allowedOnConstructable)
-                    __instance.validPosition &= root.GetComponentInParent<Constructable>() == null;
-
-                __instance.validPosition &= Builder.CheckSpace(position, rotation, PlaceTool.localBounds, PlaceTool.placeLayerMask, hit.collider);
             }
             else
-                __instance.validPosition = false;
-
-            MaterialExtensions.SetColor(__instance.renderers, ShaderPropertyID._Tint,
-                __instance.validPosition ? PlaceTool.placeColorAllow : PlaceTool.placeColorDeny);
-            if (__instance.hideInvalidGhostModel)
             {
-                __instance.ghostModel.SetActive(__instance.validPosition);
+                Inventory.main.quickSlots.SetIgnoreHotkeyInput(__instance.rotationEnabled && SnapBuilder.Config.ToggleRotation.Enabled);
             }
-
-            return false;
         }
         #endregion
 

--- a/SnapBuilder/Properties/AssemblyInfo.cs
+++ b/SnapBuilder/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.7.3")]
-[assembly: AssemblyFileVersion("1.3.7.3")]
+[assembly: AssemblyVersion("1.3.8.0")]
+[assembly: AssemblyFileVersion("1.3.8.0")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -204,14 +204,6 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             // in which case we want a more accurate normal where possible
             if (hit.collider is MeshCollider meshCollider && meshCollider.sharedMesh is Mesh)
             {
-                var gameObject = new GameObject();
-                var renderer = gameObject.AddComponent<MeshRenderer>();
-                var filter = gameObject.AddComponent<MeshFilter>();
-                filter.mesh = meshCollider.sharedMesh;
-                gameObject.transform.SetParent(hit.transform, false);
-                gameObject.transform.localScale = hit.transform.localScale * 1.01f;
-                renderer.sharedMaterial = Builder.ghostStructureMaterial;
-
                 // Set up the offsets for raycasts around the point
                 Vector3[] offsets = new Vector3[]
                 {
@@ -311,7 +303,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             child.transform.parent = empty.transform; // parent the child to the empty
             child.transform.localPosition = Vector3.zero; // Make sure the child's local position is Vector3.zero
             empty.transform.position = hit.point; // Set the parent transform's position to our chosen position
-            
+
             // In the case that the forward of the hitTransform isn't completely flat and our hit is from a MeshCollider, we are probably working with some 
             // outside piece of rock or something weird, so just use the global Vector3.forward and set the up to match the hit normal
             if (hit.collider is MeshCollider meshCollider && meshCollider.sharedMesh is Mesh && hit.transform.forward.y != 0 && !Player.main.IsInsideWalkable())

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -121,24 +121,41 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 $" ({uGUI.FormatButton(GameInput.Button.Exit, true, ", ", false)})");
         }
 
-        public static bool TryGetSnappedHitPoint(LayerMask layerMask, out RaycastHit hit,
-            out Vector3 snappedHitPoint, out Vector3 snappedHitNormal, float maxDistance = 5f)
+        private static Transform snapBuilderAimTransform;
+        private const string SnapBuilderAimTransform = "SnapBuilderAimTransform";
+        private static int lastCalculationFrame;
+        public static Transform GetAimTransform()
         {
-            Transform aimTransform = Builder.GetAimTransform();
-            aimTransform = aimTransform.FindAncestor("camOffset").parent; // Use a non-moving parent of the aimTransform instead, to counteract the movement of the camera
-            aimTransform ??= aimTransform.FindAncestor(transform => !transform.position.Equals(aimTransform.position)) ?? Builder.GetAimTransform();
-
-            // Get a new hit based on our preferred aimTransform
-            if (!Physics.Raycast(aimTransform.position,
-                                 Builder.GetAimTransform().forward,
-                                 out hit,
-                                 maxDistance,
-                                 layerMask,
-                                 QueryTriggerInteraction.Ignore))
+            Transform builderAimTransform = MainCamera.camera.transform;
+            if (!Config.Snapping.Enabled)
             {
-                snappedHitPoint = Vector3.zero;
-                snappedHitNormal = Vector3.zero;
-                return false;
+                return builderAimTransform;
+            }
+
+            snapBuilderAimTransform ??= builderAimTransform.Find(SnapBuilderAimTransform);
+            if (snapBuilderAimTransform is null)
+            {
+                snapBuilderAimTransform = new GameObject(SnapBuilderAimTransform).transform;
+                snapBuilderAimTransform.SetParent(builderAimTransform, false);
+            }
+
+            if (lastCalculationFrame == Time.frameCount)
+            {
+                return snapBuilderAimTransform;
+            }
+            lastCalculationFrame = Time.frameCount;
+
+            Transform offsetAimTransform = builderAimTransform.FindAncestor("camOffset").parent; // Use a non-moving parent of the aimTransform instead, to counteract the movement of the camera
+            offsetAimTransform ??= offsetAimTransform.FindAncestor(transform => !transform.position.Equals(offsetAimTransform.position)) ?? Builder.GetAimTransform();
+
+            if (!Physics.Raycast(offsetAimTransform.position,
+                builderAimTransform.forward,
+                out RaycastHit hit,
+                Builder.placeMaxDistance,
+                Builder.placeLayerMask,
+                QueryTriggerInteraction.Ignore))
+            {
+                return snapBuilderAimTransform;
             }
 
             // Where possible, use the transform of the parent as this should be a better reference point for localisation
@@ -175,28 +192,26 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 localPoint.z = RoundToNearest(localPoint.z, roundFactor);
             }
 
-            // Now, perform a new raycast so that we can get the normal of the new position
-            if (!Physics.Raycast(aimTransform.position,
-                                 hitTransform.TransformPoint(localPoint) - aimTransform.position, // direction from the aim transform to the new world space position of the rounded/snapped position
-                                 out hit, // overwrite hit
-                                 maxDistance,
-                                 layerMask,
-                                 QueryTriggerInteraction.Ignore))
-            {
-                snappedHitPoint = Vector3.zero;
-                snappedHitNormal = Vector3.zero;
-                return false;
-            }
+            snapBuilderAimTransform.position = offsetAimTransform.position;
+            snapBuilderAimTransform.forward = hitTransform.TransformPoint(localPoint) - snapBuilderAimTransform.position;
 
-            Builder.placementTarget = hit.collider.gameObject;
-            snappedHitPoint = hit.point;
-            snappedHitNormal = hit.normal; // Store the hit.normal as we may need to change this in certain circumstances
+            return snapBuilderAimTransform;
+        }
 
+        public static void ImproveHitNormal(ref RaycastHit hit)
+        {
             // If the hit.collider is a MeshCollider and has a sharedMesh, it is a surface like the ground or the roof of a multipurpose room,
             // in which case we want a more accurate normal where possible
-            MeshCollider meshCollider = hit.collider as MeshCollider;
-            if (meshCollider?.sharedMesh != null)
+            if (hit.collider is MeshCollider meshCollider && meshCollider.sharedMesh is Mesh)
             {
+                var gameObject = new GameObject();
+                var renderer = gameObject.AddComponent<MeshRenderer>();
+                var filter = gameObject.AddComponent<MeshFilter>();
+                filter.mesh = meshCollider.sharedMesh;
+                gameObject.transform.SetParent(hit.transform, false);
+                gameObject.transform.localScale = hit.transform.localScale * 1.01f;
+                renderer.sharedMaterial = Builder.ghostStructureMaterial;
+
                 // Set up the offsets for raycasts around the point
                 Vector3[] offsets = new Vector3[]
                 {
@@ -214,7 +229,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 // Perform a raycast from each offset, pointing down toward the surface
                 foreach (Vector3 offset in offsets)
                 {
-                    Physics.Raycast(snappedHitPoint + Vector3.up * .1f + offset * .2f,
+                    Physics.Raycast(hit.point + Vector3.up * .1f + offset * .2f,
                         Vector3.down,
                         out RaycastHit offsetHit,
                         Builder.placeMaxDistance,
@@ -228,17 +243,16 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
 
                 foreach (Vector3 normal in normals)
                 {
-                    if (normal != hit.normal)
+                    if (!normal.Equals(hit.normal))
                     {   // If the normal is not the same as the original, add it to the normal and average
-                        snappedHitNormal += normal / 2;
+                        hit.normal += normal;
+                        hit.normal /= 2;
                     }
                 }
 
                 // For sanity's sake, make sure the normal is normalised after summing & averaging
-                snappedHitNormal = snappedHitNormal.normalized;
+                hit.normal = hit.normal.normalized;
             }
-
-            return true;
         }
 
         public static void ApplyAdditiveRotation(ref float additiveRotation, out float rotationFactor)
@@ -286,28 +300,28 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             additiveRotation = RoundToNearest(additiveRotation, rotationFactor) % 360;
         }
 
-        public static Quaternion CalculateRotation(ref float additiveRotation, RaycastHit hit,
-            Vector3 snappedHitPoint, Vector3 snappedHitNormal, bool forceUpright)
+        public static Quaternion CalculateRotation(ref float additiveRotation, RaycastHit hit, bool forceUpright)
         {
             ApplyAdditiveRotation(ref additiveRotation, out float rotationFactor);
+            ImproveHitNormal(ref hit);
 
             // Instantiate empty game objects for applying rotations
             GameObject empty = new GameObject();
             GameObject child = new GameObject();
             child.transform.parent = empty.transform; // parent the child to the empty
             child.transform.localPosition = Vector3.zero; // Make sure the child's local position is Vector3.zero
-            empty.transform.position = snappedHitPoint; // Set the parent transform's position to our chosen position
-
+            empty.transform.position = hit.point; // Set the parent transform's position to our chosen position
+            
             // In the case that the forward of the hitTransform isn't completely flat and our hit is from a MeshCollider, we are probably working with some 
             // outside piece of rock or something weird, so just use the global Vector3.forward and set the up to match the hit normal
             if (hit.collider is MeshCollider meshCollider && meshCollider.sharedMesh is Mesh && hit.transform.forward.y != 0 && !Player.main.IsInsideWalkable())
             {
                 empty.transform.forward = Vector3.forward;
-                empty.transform.up = snappedHitNormal;
+                empty.transform.up = hit.normal;
             }
             else if (!forceUpright)
             {   // Rotate the parent transform so that its Y axis is aligned with the hit.normal, but only when it isn't forced upright
-                empty.transform.rotation = Quaternion.FromToRotation(Vector3.up, snappedHitNormal) * hit.transform.rotation;
+                empty.transform.rotation = Quaternion.FromToRotation(Vector3.up, hit.normal) * hit.transform.rotation;
             }
             else
             {

--- a/SnapBuilder/mod_BELOWZERO.json
+++ b/SnapBuilder/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7.3",
+    "Version": "1.3.8",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/SnapBuilder/mod_SUBNAUTICA.json
+++ b/SnapBuilder/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7.3",
+    "Version": "1.3.8",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
Migrated snapping code into a `HarmonyPostfix` on `Builder.GetAimTransform()`, which provides the following benefits:
- SnapBuilder should now be generally more compatible as we no longer use a `HarmonyPrefix` on `Builder.SetPlaceOnSurface()` which decides for itself whether or not to run the original method.
- Can strip out code that was mimicking the guts of how `Builder.SetPlaceOnSurface()` dealt with rotations, meaning that if SN ever changes this, SnapBuilder should comply with their changes!
- Manipulating the return of `Builder.GetAimTransform()` means that validation is now base on that return, using the correct hit points!
- We've also been able to strip out a bunch of code that was dealing with the fact that aim transform was pointing to a different location than where we are snapping to!

Simply put, a more elegant solution, that should make it easier to maintain or add new features to SnapBuilder!