### PR TITLE
Hotfix: Large room wall snapping

### DIFF
--- a/SnapBuilder/Properties/AssemblyInfo.cs
+++ b/SnapBuilder/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.7.1")]
-[assembly: AssemblyFileVersion("1.3.7.1")]
+[assembly: AssemblyVersion("1.3.7.2")]
+[assembly: AssemblyFileVersion("1.3.7.2")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -150,7 +150,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             };
 
             Vector3 localPoint = hitTransform.InverseTransformPoint(hit.point); // Get the hit point localised relative to the hit transform
-            Vector3 localNormal = (hitTransform.parent ?? hitTransform).InverseTransformDirection(hit.normal).normalized; // Get the hit normal localised to the hit transform
+            Vector3 localNormal = hitTransform.InverseTransformDirection(hit.normal).normalized; // Get the hit normal localised to the hit transform
 
             // Set the localised normal to absolute values for comparison
             localNormal.x = Mathf.Abs(localNormal.x);

--- a/SnapBuilder/mod_BELOWZERO.json
+++ b/SnapBuilder/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7.1",
+    "Version": "1.3.7.2",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/SnapBuilder/mod_SUBNAUTICA.json
+++ b/SnapBuilder/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "SnapBuilder",
     "DisplayName": "SnapBuilder",
     "Author": "Tobey Blaber",
-    "Version": "1.3.7.1",
+    "Version": "1.3.7.2",
     "AssemblyName": "Straitjacket.Subnautica.Mods.SnapBuilder.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
Since 1.3.7, we began using the parent (where possible) of the hit.transform for localising the hit point, as this gave better results in the case of the floor of multipurpose rooms etc.
However, we also were further using that parent's parent transform (where possible) for localising the hit normal, and in all of our testing this was working appropriately. However, we neglected to test large rooms, and this two-steps-removed localisation of the normal causes an issue in large rooms where on certain sections of the wall, snapping ceases to function.
So, this PR uses the same transform as the original step - if the parent was chosen for the hit point, use that same transform to localise the normal, never its parent. If the parent was not chosen, use the original transform for normal localisation as well.

This has been tested on the floors and walls of both multipurpose rooms and large rooms, and on standard surfaces outside, and does not seem to cause any regressions.