### PR TITLE
Refactor and improve control hints

### DIFF
--- a/SnapBuilder/Config.cs
+++ b/SnapBuilder/Config.cs
@@ -36,7 +36,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         [JsonIgnore]
         private Toggle toggleRotation;
         [JsonIgnore]
-        public Toggle ToggleRotation => toggleRotation ??= new Toggle(ToggleRotationKey, ToggleRotationMode, false);
+        public Toggle Rotation => toggleRotation ??= new Toggle(ToggleRotationKey, ToggleRotationMode, false);
 
         [JsonIgnore]
         public float RotationFactor => FineRotation.Enabled ? FineRotationRounding : RotationRounding;
@@ -82,12 +82,12 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         [Keybind(LabelLanguageId = Lang.Option.ToggleRotationKey), OnChange(nameof(EnableRotationKeyChanged))]
         public KeyCode ToggleRotationKey { get; set; } = KeyCode.Q;
         private void EnableRotationKeyChanged(KeybindChangedEventArgs e)
-            => ToggleRotation.KeyCode = e.Key;
+            => Rotation.KeyCode = e.Key;
 
         [Choice(LabelLanguageId = Lang.Option.ToggleRotationMode), OnChange(nameof(EnableRotationModeChanged))]
         public Toggle.Mode ToggleRotationMode { get; set; } = Toggle.Mode.Hold;
         private void EnableRotationModeChanged(ChoiceChangedEventArgs e)
-            => ToggleRotation.KeyMode = (Toggle.Mode)e.Index;
+            => Rotation.KeyMode = (Toggle.Mode)e.Index;
 
         [JsonConverter(typeof(FloatConverter), 2)]
         [Slider(0.01f, 1, LabelLanguageId = Lang.Option.SnapRounding, Step = 0.01f, Format = "{0:##0%}", DefaultValue = 0.5f)]
@@ -115,7 +115,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             Snapping.Reset();
             FineSnapping.Reset();
             FineRotation.Reset();
-            ToggleRotation.Reset();
+            Rotation.Reset();
         }
 
         private void Upgrade()

--- a/SnapBuilder/Config.cs
+++ b/SnapBuilder/Config.cs
@@ -33,9 +33,9 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         public Toggle FineRotation => fineRotation ??= new Toggle(FineRotationKey, FineRotationMode, false);
 
         [JsonIgnore]
-        private Toggle toggleRotation;
+        private Toggle rotation;
         [JsonIgnore]
-        public Toggle Rotation => toggleRotation ??= new Toggle(ToggleRotationKey, ToggleRotationMode, false);
+        public Toggle Rotation => rotation ??= new Toggle(ToggleRotationKey, ToggleRotationMode, false);
 
         [JsonIgnore]
         public float RotationFactor => FineRotation.Enabled ? FineRotationRounding : RotationRounding;

--- a/SnapBuilder/Config.cs
+++ b/SnapBuilder/Config.cs
@@ -18,7 +18,6 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
     {
         [JsonIgnore]
         private Toggle snapping;
-
         [JsonIgnore]
         public Toggle Snapping => snapping ??= new Toggle(ToggleSnappingKey, ToggleSnappingMode, EnabledByDefault);
 
@@ -40,6 +39,9 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
 
         [JsonIgnore]
         public float RotationFactor => FineRotation.Enabled ? FineRotationRounding : RotationRounding;
+
+        [Toggle(LabelLanguageId = Lang.Option.DisplayControlHints)]
+        public bool DisplayControlHints { get; set; } = true;
 
         [Toggle(LabelLanguageId = Lang.Option.SnappingEnabledByDefault), OnChange(nameof(EnabledByDefaultChanged))]
         public bool EnabledByDefault { get; set; } = true;
@@ -88,7 +90,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         public Toggle.Mode ToggleRotationMode { get; set; } = Toggle.Mode.Hold;
         private void EnableRotationModeChanged(ChoiceChangedEventArgs e)
             => Rotation.KeyMode = (Toggle.Mode)e.Index;
-
+        
         [JsonConverter(typeof(FloatConverter), 2)]
         [Slider(0.01f, 1, LabelLanguageId = Lang.Option.SnapRounding, Step = 0.01f, Format = "{0:##0%}", DefaultValue = 0.5f)]
         public float SnapRounding { get; set; } = 0.5f;

--- a/SnapBuilder/ControlHint.cs
+++ b/SnapBuilder/ControlHint.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace Straitjacket.Subnautica.Mods.SnapBuilder
 {
-    using Language = SMLHelper.Language;
+    using SMLHelper;
 
     internal static class ControlHint
     {
@@ -12,7 +12,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             string displayText = null;
             if (toggle.KeyCode == KeyCode.None)
             {
-                displayText = SMLHelper.Language.Get("NoInputAssigned");
+                displayText = Language.Get("NoInputAssigned");
             }
             else
             {
@@ -23,20 +23,19 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 }
                 if (string.IsNullOrEmpty(displayText))
                 {
-                    displayText = SMLHelper.Language.Get("NoInputAssigned");
+                    displayText = Language.Get("NoInputAssigned");
                 }
             }
             return $"<color=#ADF8FFFF>{displayText}</color>{(toggle.KeyMode == Toggle.Mode.Hold ? " (Hold)" : string.Empty)}";
         }
 
-        public static void Show(string hintId, Toggle toggle)
-        {
-            ErrorMessage.AddMessage($"{Language.Get(hintId)} ({FormatButton(toggle)})");
-        }
+        public static string Get(string hintId, Toggle toggle) => $"{Language.Get(hintId)} ({FormatButton(toggle)})";
 
-        public static void Show(string hintId, GameInput.Button button)
-        {
-            ErrorMessage.AddMessage($"{Language.Get(hintId)} ({uGUI.FormatButton(button, true, ", ", false)})");
-        }
+        public static string Get(string hintId, GameInput.Button button) 
+            => $"{Language.Get(hintId)} ({uGUI.FormatButton(button, true, ", ", false)})";
+
+        public static void Show(string hintId, Toggle toggle) => ErrorMessage.AddMessage(Get(hintId, toggle));
+
+        public static void Show(string hintId, GameInput.Button button) => ErrorMessage.AddMessage(Get(hintId, button));
     }
 }

--- a/SnapBuilder/ControlHint.cs
+++ b/SnapBuilder/ControlHint.cs
@@ -1,0 +1,42 @@
+﻿using SMLHelper.V2.Utility;
+using UnityEngine;
+
+namespace Straitjacket.Subnautica.Mods.SnapBuilder
+{
+    using Language = SMLHelper.Language;
+
+    internal static class ControlHint
+    {
+        private static string FormatButton(Toggle toggle)
+        {
+            string displayText = null;
+            if (toggle.KeyCode == KeyCode.None)
+            {
+                displayText = SMLHelper.Language.Get("NoInputAssigned");
+            }
+            else
+            {
+                string bindingName = KeyCodeUtils.KeyCodeToString(toggle.KeyCode);
+                if (!string.IsNullOrEmpty(bindingName))
+                {
+                    displayText = uGUI.GetDisplayTextForBinding(bindingName);
+                }
+                if (string.IsNullOrEmpty(displayText))
+                {
+                    displayText = SMLHelper.Language.Get("NoInputAssigned");
+                }
+            }
+            return $"<color=#ADF8FFFF>{displayText}</color>{(toggle.KeyMode == Toggle.Mode.Hold ? " (Hold)" : string.Empty)}";
+        }
+
+        public static void Show(string hintId, Toggle toggle)
+        {
+            ErrorMessage.AddMessage($"{Language.Get(hintId)} ({FormatButton(toggle)})");
+        }
+
+        public static void Show(string hintId, GameInput.Button button)
+        {
+            ErrorMessage.AddMessage($"{Language.Get(hintId)} ({uGUI.FormatButton(button, true, ", ", false)})");
+        }
+    }
+}

--- a/SnapBuilder/Lang.cs
+++ b/SnapBuilder/Lang.cs
@@ -15,6 +15,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
 
         internal static class Option
         {
+            public const string DisplayControlHints = "Options.DisplayControlHints";
             public const string SnappingEnabledByDefault = "Options.SnappingEnabledByDefault";
             public const string ToggleSnappingKey = "Options.ToggleSnappingKey";
             public const string ToggleSnappingMode = "Options.ToggleSnappingMode";
@@ -34,20 +35,21 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         {
             SMLHelper.Language.Set(new Dictionary<string, string>()
             {
-                [Hint.ToggleSnapping] = "Toggle snapping",
-                [Hint.ToggleFineSnapping] = "Toggle fine snapping",
-                [Hint.ToggleRotation] = "Toggle rotation",
-                [Hint.ToggleFineRotation] = "Toggle fine rotation",
+                [Hint.ToggleSnapping] = "Snapping",
+                [Hint.ToggleFineSnapping] = "Fine snapping",
+                [Hint.ToggleRotation] = "Rotation",
+                [Hint.ToggleFineRotation] = "Fine rotation",
                 [Hint.HolsterItem] = "Holster item",
+                [Option.DisplayControlHints] = "Display control hints",
                 [Option.SnappingEnabledByDefault] = "Snapping enabled by default",
-                [Option.ToggleSnappingKey] = "Toggle snapping button",
-                [Option.ToggleSnappingMode] = "Toggle snapping mode",
+                [Option.ToggleSnappingKey] = "Snapping button",
+                [Option.ToggleSnappingMode] = "Snapping mode",
                 [Option.FineSnappingKey] = "Fine snapping button",
                 [Option.FineSnappingMode] = "Fine snapping mode",
                 [Option.FineRotationKey] = "Fine rotation button",
                 [Option.FineRotationMode] = "Fine rotation mode",
-                [Option.ToggleRotationKey] = "Toggle rotation button (for placeable items)",
-                [Option.ToggleRotationMode] = "Toggle rotation mode (for placeable items)",
+                [Option.ToggleRotationKey] = "Rotation button (for placeable items)",
+                [Option.ToggleRotationMode] = "Rotation mode (for placeable items)",
                 [Option.SnapRounding] = "Snap rounding",
                 [Option.FineSnapRounding] = "Fine snap rounding",
                 [Option.RotationRounding] = "Rotation rounding (degrees)",

--- a/SnapBuilder/Patches/BuilderPatch.cs
+++ b/SnapBuilder/Patches/BuilderPatch.cs
@@ -5,15 +5,13 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 {
     internal static class BuilderPatch
     {
-#if SUBNAUTICA
         #region Builder.Begin
+#if SUBNAUTICA
         [HarmonyPatch(typeof(Builder), nameof(Builder.Begin))]
         [HarmonyPrefix]
-        public static void BeginPrefix(out bool __state)
+        public static void BeginHintsPrefix(out bool __state)
         {
-            SnapBuilder.Config.ResetToggles();
-
-            __state = Builder.ghostModel == null;
+            __state = SnapBuilder.Config.DisplayControlHints && Builder.ghostModel == null;
 
             if (__state)
             {
@@ -24,15 +22,19 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 
         [HarmonyPatch(typeof(Builder), nameof(Builder.Begin))]
         [HarmonyPostfix]
-        public static void BeginPostfix(bool __state)
+        public static void BeginHintsPostfix(bool __state)
         {
             if (__state && Builder.rotationEnabled)
             {
                 ControlHint.Show(Lang.Hint.ToggleFineRotation, SnapBuilder.Config.FineRotation);
             }
         }
-        #endregion
 #endif
+
+        [HarmonyPatch(typeof(Builder), nameof(Builder.Begin))]
+        [HarmonyPostfix]
+        public static void BeginResetTogglesPostfix() => SnapBuilder.Config.ResetToggles();
+        #endregion
 
         #region Builder.GetAimTransform
         [HarmonyPatch(typeof(Builder), nameof(Builder.GetAimTransform))]

--- a/SnapBuilder/Patches/BuilderPatch.cs
+++ b/SnapBuilder/Patches/BuilderPatch.cs
@@ -5,10 +5,11 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 {
     internal static class BuilderPatch
     {
+#if SUBNAUTICA
         #region Builder.Begin
         [HarmonyPatch(typeof(Builder), nameof(Builder.Begin))]
         [HarmonyPrefix]
-        public static void BeginPrefix(ref bool __state)
+        public static void BeginPrefix(out bool __state)
         {
             SnapBuilder.Config.ResetToggles();
 
@@ -31,6 +32,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
             }
         }
         #endregion
+#endif
 
         #region Builder.GetAimTransform
         [HarmonyPatch(typeof(Builder), nameof(Builder.GetAimTransform))]

--- a/SnapBuilder/Patches/BuilderPatch.cs
+++ b/SnapBuilder/Patches/BuilderPatch.cs
@@ -14,14 +14,21 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 
             __state = Builder.ghostModel == null;
 
-            SnapBuilder.ShowSnappingHint(__state);
+            if (__state)
+            {
+                ControlHint.Show(Lang.Hint.ToggleSnapping, SnapBuilder.Config.Snapping);
+                ControlHint.Show(Lang.Hint.ToggleFineSnapping, SnapBuilder.Config.FineSnapping);
+            }
         }
 
         [HarmonyPatch(typeof(Builder), nameof(Builder.Begin))]
         [HarmonyPostfix]
         public static void BeginPostfix(bool __state)
         {
-            SnapBuilder.ShowToggleFineRotationHint(__state && Builder.rotationEnabled);
+            if (__state && Builder.rotationEnabled)
+            {
+                ControlHint.Show(Lang.Hint.ToggleFineRotation, SnapBuilder.Config.FineRotation);
+            }
         }
         #endregion
 

--- a/SnapBuilder/Patches/BuilderToolPatch.cs
+++ b/SnapBuilder/Patches/BuilderToolPatch.cs
@@ -1,0 +1,81 @@
+﻿#if BELOWZERO
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
+{
+    using SMLHelper;
+
+    internal static class BuilderToolPatch
+    {
+        #region Builder.GetCustomUseText
+        public struct GetCustomUseTextState
+        {
+            public readonly bool WasPlacing;
+            public readonly bool WasPlacingRotatable;
+            public readonly bool WasSnappingEnabled;
+
+            public GetCustomUseTextState(bool wasPlacing, bool wasPlacingRotatable, bool wasSnappingEnabled)
+            {
+                WasPlacing = wasPlacing;
+                WasPlacingRotatable = wasPlacingRotatable;
+                WasSnappingEnabled = wasSnappingEnabled;
+            }
+        }
+
+        private static bool wasSnappingEnabled = SnapBuilder.Config.Snapping.Enabled;
+        [HarmonyPatch(typeof(BuilderTool), nameof(BuilderTool.GetCustomUseText))]
+        [HarmonyPrefix]
+        public static void GetCustomUseTextPrefix(BuilderTool __instance, out GetCustomUseTextState __state)
+        {
+            __state = new GetCustomUseTextState(wasPlacing: __instance.wasPlacing,
+                                wasPlacingRotatable: __instance.wasPlacingRotatable,
+                                wasSnappingEnabled: wasSnappingEnabled);
+
+            wasSnappingEnabled = SnapBuilder.Config.Snapping.Enabled;
+        }
+
+        [HarmonyPatch(typeof(BuilderTool), nameof(BuilderTool.GetCustomUseText))]
+        [HarmonyPostfix]
+        public static string GetCustomUseTextPostfix(string customUseText, BuilderTool __instance, GetCustomUseTextState __state)
+        {
+            if (Builder.isPlacing
+                && (!__state.WasPlacing
+                    || (SnapBuilder.Config.Snapping.Enabled != __state.WasSnappingEnabled)))
+            {
+                List<string> lines = customUseText.Split('\n').ToList();
+
+                if (!SnapBuilder.Config.Snapping.Enabled)
+                {
+                    lines.RemoveAll(line => line.Contains(Language.Get(Lang.Hint.ToggleFineSnapping))
+                                            || line.Contains(Language.Get(Lang.Hint.ToggleFineRotation)));
+
+                    lines.Insert(1, ControlHint.Get(Lang.Hint.ToggleSnapping, SnapBuilder.Config.Snapping));
+                }
+                else
+                {
+                    lines.RemoveAll(line => line.Contains(Language.Get(Lang.Hint.ToggleSnapping)));
+
+                    lines.Insert(1,
+                        $"{ControlHint.Get(Lang.Hint.ToggleSnapping, SnapBuilder.Config.Snapping)}, " +
+                        $"{ControlHint.Get(Lang.Hint.ToggleFineSnapping, SnapBuilder.Config.FineSnapping)}");
+
+                    if (Builder.rotationEnabled
+                        && (!__state.WasPlacingRotatable
+                            || (SnapBuilder.Config.Snapping.Enabled && !__state.WasSnappingEnabled)))
+                    {
+                        lines.Add(ControlHint.Get(Lang.Hint.ToggleFineRotation, SnapBuilder.Config.FineRotation));
+                    }
+                }
+
+                customUseText = string.Join(Environment.NewLine, lines.Distinct());
+            }
+
+            return __instance.customUseText = customUseText;
+        }
+        #endregion
+    }
+}
+#endif

--- a/SnapBuilder/Patches/BuilderToolPatch.cs
+++ b/SnapBuilder/Patches/BuilderToolPatch.cs
@@ -16,34 +16,50 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
             public readonly bool WasPlacing;
             public readonly bool WasPlacingRotatable;
             public readonly bool WasSnappingEnabled;
+            public readonly bool WereHintsEnabled;
 
-            public GetCustomUseTextState(bool wasPlacing, bool wasPlacingRotatable, bool wasSnappingEnabled)
+            public GetCustomUseTextState(bool wasPlacing, bool wasPlacingRotatable, bool wasSnappingEnabled, bool wereHintsEnabled)
             {
                 WasPlacing = wasPlacing;
                 WasPlacingRotatable = wasPlacingRotatable;
                 WasSnappingEnabled = wasSnappingEnabled;
+                WereHintsEnabled = wereHintsEnabled;
             }
         }
 
         private static bool wasSnappingEnabled = SnapBuilder.Config.Snapping.Enabled;
+        private static bool wereHintsEnabled = SnapBuilder.Config.DisplayControlHints;
         [HarmonyPatch(typeof(BuilderTool), nameof(BuilderTool.GetCustomUseText))]
         [HarmonyPrefix]
         public static void GetCustomUseTextPrefix(BuilderTool __instance, out GetCustomUseTextState __state)
         {
             __state = new GetCustomUseTextState(wasPlacing: __instance.wasPlacing,
                                 wasPlacingRotatable: __instance.wasPlacingRotatable,
-                                wasSnappingEnabled: wasSnappingEnabled);
+                                wasSnappingEnabled: wasSnappingEnabled,
+                                wereHintsEnabled: wereHintsEnabled);
 
             wasSnappingEnabled = SnapBuilder.Config.Snapping.Enabled;
+            wereHintsEnabled = SnapBuilder.Config.DisplayControlHints;
         }
 
         [HarmonyPatch(typeof(BuilderTool), nameof(BuilderTool.GetCustomUseText))]
         [HarmonyPostfix]
         public static string GetCustomUseTextPostfix(string customUseText, BuilderTool __instance, GetCustomUseTextState __state)
         {
-            if (Builder.isPlacing
-                && (!__state.WasPlacing
-                    || (SnapBuilder.Config.Snapping.Enabled != __state.WasSnappingEnabled)))
+            if (!SnapBuilder.Config.DisplayControlHints && __state.WereHintsEnabled)
+            {
+                List<string> lines = customUseText.Split('\n').ToList();
+
+                lines.RemoveAll(line => line.Contains(Language.Get(Lang.Hint.ToggleSnapping))
+                                        || line.Contains(Language.Get(Lang.Hint.ToggleFineSnapping))
+                                        || line.Contains(Language.Get(Lang.Hint.ToggleFineRotation)));
+            }
+            else if (SnapBuilder.Config.DisplayControlHints
+                     && Builder.isPlacing
+                     && (!__state.WereHintsEnabled
+                         || !__state.WasPlacing
+                         || (Builder.rotationEnabled != __state.WasPlacingRotatable)
+                         || (SnapBuilder.Config.Snapping.Enabled != __state.WasSnappingEnabled)))
             {
                 List<string> lines = customUseText.Split('\n').ToList();
 
@@ -63,10 +79,15 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
                         $"{ControlHint.Get(Lang.Hint.ToggleFineSnapping, SnapBuilder.Config.FineSnapping)}");
 
                     if (Builder.rotationEnabled
-                        && (!__state.WasPlacingRotatable
+                        && (!__state.WereHintsEnabled
+                            || !__state.WasPlacingRotatable
                             || (SnapBuilder.Config.Snapping.Enabled && !__state.WasSnappingEnabled)))
                     {
                         lines.Add(ControlHint.Get(Lang.Hint.ToggleFineRotation, SnapBuilder.Config.FineRotation));
+                    }
+                    else if (!Builder.rotationEnabled)
+                    {
+                        lines.RemoveAll(line => line.Contains(Language.Get(Lang.Hint.ToggleFineRotation)));
                     }
                 }
 

--- a/SnapBuilder/Patches/PlaceToolPatch.cs
+++ b/SnapBuilder/Patches/PlaceToolPatch.cs
@@ -13,7 +13,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 
             __state = __instance.ghostModel == null;
 
-            if (__state)
+            if (__state && SnapBuilder.Config.DisplayControlHints)
             {
                 ControlHint.Show(Lang.Hint.ToggleSnapping, SnapBuilder.Config.Snapping);
                 ControlHint.Show(Lang.Hint.ToggleFineSnapping, SnapBuilder.Config.FineSnapping);
@@ -24,7 +24,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
         [HarmonyPostfix]
         public static void Postfix(PlaceTool __instance, bool __state)
         {
-            if (__state && __instance.rotationEnabled)
+            if (__state && SnapBuilder.Config.DisplayControlHints && __instance.rotationEnabled)
             {
                 ControlHint.Show(Lang.Hint.ToggleRotation, SnapBuilder.Config.Rotation);
                 ControlHint.Show(Lang.Hint.ToggleFineRotation, SnapBuilder.Config.FineRotation);

--- a/SnapBuilder/Patches/PlaceToolPatch.cs
+++ b/SnapBuilder/Patches/PlaceToolPatch.cs
@@ -13,16 +13,23 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 
             __state = __instance.ghostModel == null;
 
-            SnapBuilder.ShowSnappingHint(__state);
+            if (__state)
+            {
+                ControlHint.Show(Lang.Hint.ToggleSnapping, SnapBuilder.Config.Snapping);
+                ControlHint.Show(Lang.Hint.ToggleFineSnapping, SnapBuilder.Config.FineSnapping);
+            }
         }
 
         [HarmonyPatch(typeof(PlaceTool), nameof(PlaceTool.CreateGhostModel))]
         [HarmonyPostfix]
         public static void Postfix(PlaceTool __instance, bool __state)
         {
-            SnapBuilder.ShowToggleRotationHint(__state && __instance.rotationEnabled);
-            SnapBuilder.ShowToggleFineRotationHint(__state && __instance.rotationEnabled);
-            SnapBuilder.ShowHolsterHint(__state && __instance.rotationEnabled);
+            if (__state && __instance.rotationEnabled)
+            {
+                ControlHint.Show(Lang.Hint.ToggleRotation, SnapBuilder.Config.Rotation);
+                ControlHint.Show(Lang.Hint.ToggleFineRotation, SnapBuilder.Config.FineRotation);
+                ControlHint.Show(Lang.Hint.HolsterItem, GameInput.Button.Exit);
+            }
         }
         #endregion
 
@@ -37,7 +44,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
             }
             else
             {
-                Inventory.main.quickSlots.SetIgnoreHotkeyInput(__instance.rotationEnabled && SnapBuilder.Config.ToggleRotation.Enabled);
+                Inventory.main.quickSlots.SetIgnoreHotkeyInput(__instance.rotationEnabled && SnapBuilder.Config.Rotation.Enabled);
             }
         }
         #endregion

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -4,10 +4,10 @@ using System.Reflection;
 using HarmonyLib;
 using SMLHelper.V2.Handlers;
 using UnityEngine;
-using Logger = BepInEx.Subnautica.Logger;
 
 namespace Straitjacket.Subnautica.Mods.SnapBuilder
 {
+    using BepInEx.Subnautica;
     using ExtensionMethods.UnityEngine;
     using Patches;
 
@@ -49,6 +49,9 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             var harmony = new Harmony("SnapBuilder");
             harmony.PatchAll(typeof(BuilderPatch));
             harmony.PatchAll(typeof(PlaceToolPatch));
+#if BELOWZERO
+            harmony.PatchAll(typeof(BuilderToolPatch));
+#endif
 
             stopwatch.Stop();
             Logger.LogInfo($"Harmony patches applied in {stopwatch.ElapsedMilliseconds}ms.");

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Reflection;
 using HarmonyLib;
 using SMLHelper.V2.Handlers;
-using SMLHelper.V2.Utility;
 using UnityEngine;
 using Logger = BepInEx.Subnautica.Logger;
 
@@ -53,66 +52,6 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
 
             stopwatch.Stop();
             Logger.LogInfo($"Harmony patches applied in {stopwatch.ElapsedMilliseconds}ms.");
-        }
-
-        public static string FormatButton(Toggle toggle)
-        {
-            string displayText = null;
-            if (toggle.KeyCode == KeyCode.None)
-            {
-                displayText = SMLHelper.Language.Get("NoInputAssigned");
-            }
-            else
-            {
-                string bindingName = KeyCodeUtils.KeyCodeToString(toggle.KeyCode);
-                if (!string.IsNullOrEmpty(bindingName))
-                {
-                    displayText = uGUI.GetDisplayTextForBinding(bindingName);
-                }
-                if (string.IsNullOrEmpty(displayText))
-                {
-                    displayText = SMLHelper.Language.Get("NoInputAssigned");
-                }
-            }
-            return $"<color=#ADF8FFFF>{displayText}</color>{(toggle.KeyMode == Toggle.Mode.Hold ? " (Hold)" : string.Empty)}";
-        }
-
-        public static void ShowSnappingHint(bool shouldShow = true)
-        {
-            if (!shouldShow)
-                return;
-
-            ErrorMessage.AddError(SMLHelper.Language.Get(Lang.Hint.ToggleSnapping) +
-                    $" ({FormatButton(Config.Snapping)})");
-            ErrorMessage.AddError(SMLHelper.Language.Get(Lang.Hint.ToggleFineSnapping) +
-                $" ({FormatButton(Config.FineSnapping)})");
-        }
-
-        public static void ShowToggleFineRotationHint(bool shouldShow = true)
-        {
-            if (!shouldShow)
-                return;
-
-            ErrorMessage.AddError(SMLHelper.Language.Get(Lang.Hint.ToggleFineRotation) +
-                $" ({FormatButton(Config.FineRotation)})");
-        }
-
-        public static void ShowToggleRotationHint(bool shouldShow = true)
-        {
-            if (!shouldShow)
-                return;
-
-            ErrorMessage.AddError(SMLHelper.Language.Get(Lang.Hint.ToggleRotation) +
-                $" ({FormatButton(Config.ToggleRotation)})");
-        }
-
-        public static void ShowHolsterHint(bool shouldShow = true)
-        {
-            if (!shouldShow)
-                return;
-
-            ErrorMessage.AddError(SMLHelper.Language.Get(Lang.Hint.HolsterItem) +
-                $" ({uGUI.FormatButton(GameInput.Button.Exit, true, ", ", false)})");
         }
 
         /// <summary>

--- a/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
+++ b/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
@@ -97,6 +97,7 @@
     <Compile Include="ControlHint.cs" />
     <Compile Include="Lang.cs" />
     <Compile Include="Patches\BuilderPatch.cs" />
+    <Compile Include="Patches\BuilderToolPatch.cs" />
     <Compile Include="Patches\PlaceToolPatch.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="SnapBuilder.cs" />

--- a/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
+++ b/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
@@ -94,6 +94,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config.cs" />
+    <Compile Include="ControlHint.cs" />
     <Compile Include="Lang.cs" />
     <Compile Include="Patches\BuilderPatch.cs" />
     <Compile Include="Patches\PlaceToolPatch.cs" />


### PR DESCRIPTION
## Changes in this pull request
- Moved methods relating to displaying control hints out of `SnapBuilder` and into their own discreet class `ControlHint`
- Streamlined the default control hints and options text
- Display method for control hints has been updated for BZ, since vanilla hints no longer use the `ErrorMessage.AddError` method as they did before 1.0 release (and still do in SN).

**Note**: I have not had a chance to test placeable objects in BZ since the game doesn't seem to come with any, but does seem to support them. As such placeable objects control hints currently utilise `ErrorMessage.AddMessage` instead. Will need to either find a mod that adds placeable items, or find a vanilla placeable item for testing to further update the control hints for BZ, but this can come later in a future patch.