### PR TITLE
Improve hit colliders where possible

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "Straitjacket.Math"]
 	path = Straitjacket.Math
 	url = https://github.com/tobeyStraitjacket/Straitjacket.Math
+[submodule "Straitjacket.SceneCache"]
+	path = Straitjacket.SceneCache
+	url = https://github.com/tobeyStraitjacket/Straitjacket.SceneCache

--- a/SnapBuilder.sln
+++ b/SnapBuilder.sln
@@ -15,14 +15,18 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Straitjacket.ExtensionMetho
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Straitjacket.Math", "Straitjacket.Math\Straitjacket.Math\Straitjacket.Math.shproj", "{EDF9AFB9-5A40-4818-8004-95E22D5B7BA0}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Straitjacket.SceneCache", "Straitjacket.SceneCache\Straitjacket.SceneCache\Straitjacket.SceneCache.shproj", "{2635AE48-3546-41B7-A036-BA190D8C8022}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Straitjacket.SceneCache\Straitjacket.SceneCache\Straitjacket.SceneCache.projitems*{2635ae48-3546-41b7-a036-ba190d8c8022}*SharedItemsImports = 13
 		Toggle\Toggle\Toggle.projitems*{2e9fec3f-6690-46e8-b676-9778d4b1292a}*SharedItemsImports = 13
 		BepInEx.Logger\Logger\Logger.projitems*{32f6ed8c-0f9a-409d-a404-ee068789c72f}*SharedItemsImports = 13
 		BepInEx.Logger\Logger\Logger.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
 		SMLHelper.Language\SMLHelper.Language\Language.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
 		Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
 		Straitjacket.Math\Straitjacket.Math\Straitjacket.Math.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
+		Straitjacket.SceneCache\Straitjacket.SceneCache\Straitjacket.SceneCache.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
 		Toggle\Toggle\Toggle.projitems*{90b8cfbb-759d-4e62-b923-05c2fefe5cb3}*SharedItemsImports = 4
 		Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine.projitems*{91e30b75-0933-43cc-98ff-7c9dcca7f849}*SharedItemsImports = 13
 		SMLHelper.Language\SMLHelper.Language\Language.projitems*{ad133c9e-a9a1-4dbc-bd93-7149d32cb98a}*SharedItemsImports = 13

--- a/SnapBuilder/Cache.cs
+++ b/SnapBuilder/Cache.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Straitjacket.Subnautica.Mods.SnapBuilder
+{
+    using ExtensionMethods.UnityEngine;
+    using SceneManagement;
+
+    internal class Cache
+    {
+        /// <summary>
+        /// The camera transform, as per the original Builder.GetAimTransform()
+        /// </summary>
+        public Transform BuilderAimTransform => MainCamera.camera.transform;
+        public const string SnapBuilderAimTransformName = "SnapBuilderAimTransform";
+
+        private SceneCache<Transform> snapBuilderAimTransformCache;
+        /// <summary>
+        /// The transform attached to our custom GameObject for snapped aiming
+        /// </summary>
+        public Transform SnapBuilderAimTransform
+        {
+            get
+            {
+                snapBuilderAimTransformCache ??= new SceneCache<Transform>();
+                snapBuilderAimTransformCache.Data ??= BuilderAimTransform.Find(SnapBuilderAimTransformName);
+                if (snapBuilderAimTransformCache.Data is null)
+                {
+                    snapBuilderAimTransformCache.Data = new GameObject(SnapBuilderAimTransformName).transform;
+                    snapBuilderAimTransformCache.Data.SetParent(BuilderAimTransform, false);
+                }
+
+                return snapBuilderAimTransformCache.Data;
+            }
+        }
+
+        private SceneCache<Transform> offsetAimTransformCache;
+        /// <summary>
+        /// A non-moving parent of the MainCamera transform, to counteract head-bobbing
+        /// </summary>
+        public Transform OffsetAimTransform
+        {
+            get
+            {
+                offsetAimTransformCache ??= new SceneCache<Transform>();
+                return offsetAimTransformCache.Data ??= BuilderAimTransform.FindAncestor("camOffset").parent
+                        ?? BuilderAimTransform.FindAncestor(transform => !transform.position.Equals(OffsetAimTransform.position))
+                        ?? BuilderAimTransform;
+            }
+        }
+
+        private SceneCache<Dictionary<Collider, Mesh>> originalMeshByColliderCache;
+        /// <summary>
+        /// A dictionary of colliders mapped to their original mesh
+        /// </summary>
+        public Dictionary<Collider, Mesh> OriginalMeshByCollider
+        {
+            get
+            {
+                originalMeshByColliderCache ??= new SceneCache<Dictionary<Collider, Mesh>>();
+                return originalMeshByColliderCache.Data ??= new Dictionary<Collider, Mesh>();
+            }
+        }
+
+        private SceneCache<Dictionary<Collider, Mesh>> improvedMeshByColliderCache;
+        /// <summary>
+        /// A dictionary of colliders mapped to the map chosen to replace the original
+        /// </summary>
+        public Dictionary<Collider, Mesh> ImprovedMeshByCollider
+        {
+            get
+            {
+                improvedMeshByColliderCache ??= new SceneCache<Dictionary<Collider, Mesh>>();
+                return improvedMeshByColliderCache.Data ??= new Dictionary<Collider, Mesh>();
+            }
+        }
+
+        private SceneCache<Dictionary<Collider, bool>> isImprovedByColliderCache;
+        /// <summary>
+        /// A dictionary of collider mapped to whether they are currently improved
+        /// </summary>
+        public Dictionary<Collider, bool> IsImprovedByCollider
+        {
+            get
+            {
+                isImprovedByColliderCache ??= new SceneCache<Dictionary<Collider, bool>>();
+                return isImprovedByColliderCache.Data ??= new Dictionary<Collider, bool>();
+            }
+        }
+
+        private SceneCache<Material> colliderMaterialCache;
+        public Material ColliderMaterial
+        {
+            get
+            {
+                colliderMaterialCache ??= new SceneCache<Material>();
+                return colliderMaterialCache.Data ??= new Material(Builder.ghostStructureMaterial);
+            }
+        }
+
+        private SceneCache<Collider> lastColliderCache;
+        /// <summary>
+        /// The Collider that the player most recently aimed at, or null.
+        /// </summary>
+        public Collider LastCollider
+        {
+            get => (lastColliderCache ??= new SceneCache<Collider>()).Data;
+            set => (lastColliderCache ??= new SceneCache<Collider>()).Data = value;
+        }
+    }
+}

--- a/SnapBuilder/Config.cs
+++ b/SnapBuilder/Config.cs
@@ -60,6 +60,9 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         private void DetailedColliderEnabledByDefaultChanged(ToggleChangedEventArgs e)
             => DetailedCollider.EnabledByDefault = e.Value;
 
+        [Toggle(LabelLanguageId = Lang.Option.RenderImprovableColliders)]
+        public bool RenderImprovableColliders { get; set; } = true;
+
         [Keybind(LabelLanguageId = Lang.Option.ToggleSnappingKey), OnChange(nameof(ToggleSnappingKeyChanged))]
         public KeyCode ToggleSnappingKey { get; set; } = KeyCode.Mouse2;
         private void ToggleSnappingKeyChanged(KeybindChangedEventArgs e)

--- a/SnapBuilder/Config.cs
+++ b/SnapBuilder/Config.cs
@@ -40,6 +40,13 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         [JsonIgnore]
         public float RotationFactor => FineRotation.Enabled ? FineRotationRounding : RotationRounding;
 
+        [JsonIgnore]
+        private Toggle detailedColliders;
+        [JsonIgnore]
+        public Toggle DetailedCollider => detailedColliders ??= new Toggle(DetailedColliderKey,
+                                                                           DetailedColliderMode,
+                                                                           DetailedColliderEnabledByDefault);
+
         [Toggle(LabelLanguageId = Lang.Option.DisplayControlHints)]
         public bool DisplayControlHints { get; set; } = true;
 
@@ -47,6 +54,11 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         public bool EnabledByDefault { get; set; } = true;
         private void EnabledByDefaultChanged(ToggleChangedEventArgs e)
             => Snapping.EnabledByDefault = e.Value;
+
+        [Toggle(LabelLanguageId = Lang.Option.DetailedColliderEnabledByDefault), OnChange(nameof(DetailedColliderEnabledByDefaultChanged))]
+        public bool DetailedColliderEnabledByDefault { get; set; } = true;
+        private void DetailedColliderEnabledByDefaultChanged(ToggleChangedEventArgs e)
+            => DetailedCollider.EnabledByDefault = e.Value;
 
         [Keybind(LabelLanguageId = Lang.Option.ToggleSnappingKey), OnChange(nameof(ToggleSnappingKeyChanged))]
         public KeyCode ToggleSnappingKey { get; set; } = KeyCode.Mouse2;
@@ -90,7 +102,17 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         public Toggle.Mode ToggleRotationMode { get; set; } = Toggle.Mode.Hold;
         private void EnableRotationModeChanged(ChoiceChangedEventArgs e)
             => Rotation.KeyMode = (Toggle.Mode)e.Index;
-        
+
+        [Keybind(LabelLanguageId = Lang.Option.DetailedColliderKey), OnChange(nameof(DetailedColliderKeyChanged))]
+        public KeyCode DetailedColliderKey { get; set; } = KeyCode.F;
+        private void DetailedColliderKeyChanged(KeybindChangedEventArgs e)
+            => DetailedCollider.KeyCode = e.Key;
+
+        [Choice(LabelLanguageId = Lang.Option.DetailedColliderMode), OnChange(nameof(DetailedColliderModeChanged))]
+        public Toggle.Mode DetailedColliderMode { get; set; } = Toggle.Mode.Press;
+        private void DetailedColliderModeChanged(ChoiceChangedEventArgs e)
+            => DetailedCollider.KeyMode = (Toggle.Mode)e.Index;
+
         [JsonConverter(typeof(FloatConverter), 2)]
         [Slider(0.01f, 1, LabelLanguageId = Lang.Option.SnapRounding, Step = 0.01f, Format = "{0:##0%}", DefaultValue = 0.5f)]
         public float SnapRounding { get; set; } = 0.5f;
@@ -118,6 +140,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             FineSnapping.Reset();
             FineRotation.Reset();
             Rotation.Reset();
+            DetailedCollider.Reset();
         }
 
         private void Upgrade()

--- a/SnapBuilder/Lang.cs
+++ b/SnapBuilder/Lang.cs
@@ -11,6 +11,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             public const string ToggleRotation = "GhostToggleRotationHint";
             public const string ToggleFineRotation = "GhostToggleFineRotationHint";
             public const string HolsterItem = "GhostHolsterItemHint";
+            public const string DetailedCollider = "GhostToggleDetailedColliderHint";
         }
 
         internal static class Option
@@ -25,6 +26,9 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             public const string FineRotationMode = "Options.FineRotationMode";
             public const string ToggleRotationKey = "Options.ToggleRotationKey";
             public const string ToggleRotationMode = "Options.ToggleRotationMode";
+            public const string DetailedColliderEnabledByDefault = "Options.DetailedColliderEnabledByDefault";
+            public const string DetailedColliderKey = "Options.DetailedColliderKey";
+            public const string DetailedColliderMode = "Options.DetailedColliderMode";
             public const string SnapRounding = "Options.SnapRounding";
             public const string FineSnapRounding = "Options.FineSnapRounding";
             public const string RotationRounding = "Options.RotationRounding";
@@ -35,12 +39,13 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         {
             SMLHelper.Language.Set(new Dictionary<string, string>()
             {
+                [Option.DisplayControlHints] = "Display control hints",
                 [Hint.ToggleSnapping] = "Snapping",
                 [Hint.ToggleFineSnapping] = "Fine snapping",
                 [Hint.ToggleRotation] = "Rotation",
                 [Hint.ToggleFineRotation] = "Fine rotation",
                 [Hint.HolsterItem] = "Holster item",
-                [Option.DisplayControlHints] = "Display control hints",
+                [Hint.DetailedCollider] = "Detailed collider",
                 [Option.SnappingEnabledByDefault] = "Snapping enabled by default",
                 [Option.ToggleSnappingKey] = "Snapping button",
                 [Option.ToggleSnappingMode] = "Snapping mode",
@@ -50,6 +55,9 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 [Option.FineRotationMode] = "Fine rotation mode",
                 [Option.ToggleRotationKey] = "Rotation button (for placeable items)",
                 [Option.ToggleRotationMode] = "Rotation mode (for placeable items)",
+                [Option.DetailedColliderEnabledByDefault] = "Detailed collider enabled by default",
+                [Option.DetailedColliderKey] = "Detailed collider button",
+                [Option.DetailedColliderMode] = "Detailed collider mode",
                 [Option.SnapRounding] = "Snap rounding",
                 [Option.FineSnapRounding] = "Fine snap rounding",
                 [Option.RotationRounding] = "Rotation rounding (degrees)",

--- a/SnapBuilder/Lang.cs
+++ b/SnapBuilder/Lang.cs
@@ -6,18 +6,21 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
     {
         internal static class Hint
         {
-            public const string ToggleSnapping = "GhostToggleSnappingHint";
-            public const string ToggleFineSnapping = "GhostToggleFineSnappingHint";
-            public const string ToggleRotation = "GhostToggleRotationHint";
-            public const string ToggleFineRotation = "GhostToggleFineRotationHint";
-            public const string HolsterItem = "GhostHolsterItemHint";
-            public const string DetailedCollider = "GhostToggleDetailedColliderHint";
+            public const string ToggleSnapping = "Hints.ToggleSnapping";
+            public const string ToggleFineSnapping = "Hints.ToggleFineSnapping";
+            public const string ToggleRotation = "Hints.ToggleRotation";
+            public const string ToggleFineRotation = "Hints.ToggleFineRotation";
+            public const string HolsterItem = "Hints.HolsterItem";
+            public const string DetailedCollider = "Hints.DetailedCollider";
+            public const string OriginalCollider = "Hints.OriginalCollider";
         }
 
         internal static class Option
         {
             public const string DisplayControlHints = "Options.DisplayControlHints";
             public const string SnappingEnabledByDefault = "Options.SnappingEnabledByDefault";
+            public const string DetailedColliderEnabledByDefault = "Options.DetailedColliderEnabledByDefault";
+            public const string RenderImprovableColliders = "Options.RenderImprovableColliders";
             public const string ToggleSnappingKey = "Options.ToggleSnappingKey";
             public const string ToggleSnappingMode = "Options.ToggleSnappingMode";
             public const string FineSnappingKey = "Options.FineSnappingKey";
@@ -26,7 +29,6 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             public const string FineRotationMode = "Options.FineRotationMode";
             public const string ToggleRotationKey = "Options.ToggleRotationKey";
             public const string ToggleRotationMode = "Options.ToggleRotationMode";
-            public const string DetailedColliderEnabledByDefault = "Options.DetailedColliderEnabledByDefault";
             public const string DetailedColliderKey = "Options.DetailedColliderKey";
             public const string DetailedColliderMode = "Options.DetailedColliderMode";
             public const string SnapRounding = "Options.SnapRounding";
@@ -39,14 +41,17 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
         {
             SMLHelper.Language.Set(new Dictionary<string, string>()
             {
-                [Option.DisplayControlHints] = "Display control hints",
                 [Hint.ToggleSnapping] = "Snapping",
                 [Hint.ToggleFineSnapping] = "Fine snapping",
                 [Hint.ToggleRotation] = "Rotation",
                 [Hint.ToggleFineRotation] = "Fine rotation",
                 [Hint.HolsterItem] = "Holster item",
                 [Hint.DetailedCollider] = "Detailed collider",
+                [Hint.OriginalCollider] = "Original collider",
+                [Option.DisplayControlHints] = "Display control hints",
                 [Option.SnappingEnabledByDefault] = "Snapping enabled by default",
+                [Option.DetailedColliderEnabledByDefault] = "Detailed collider enabled by default",
+                [Option.RenderImprovableColliders] = "Render improvable colliders",
                 [Option.ToggleSnappingKey] = "Snapping button",
                 [Option.ToggleSnappingMode] = "Snapping mode",
                 [Option.FineSnappingKey] = "Fine snapping button",
@@ -55,7 +60,6 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                 [Option.FineRotationMode] = "Fine rotation mode",
                 [Option.ToggleRotationKey] = "Rotation button (for placeable items)",
                 [Option.ToggleRotationMode] = "Rotation mode (for placeable items)",
-                [Option.DetailedColliderEnabledByDefault] = "Detailed collider enabled by default",
                 [Option.DetailedColliderKey] = "Detailed collider button",
                 [Option.DetailedColliderMode] = "Detailed collider mode",
                 [Option.SnapRounding] = "Snap rounding",

--- a/SnapBuilder/Patches/BuilderPatch.cs
+++ b/SnapBuilder/Patches/BuilderPatch.cs
@@ -28,7 +28,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
             {
                 ControlHint.Show(Lang.Hint.ToggleFineRotation, SnapBuilder.Config.FineRotation);
             }
-            if (__state && SnapBuilder.ColliderIsImprovable)
+            if (__state && SnapBuilder.IsColliderImprovable())
             {
                 ControlHint.Show(Lang.Hint.DetailedCollider, SnapBuilder.Config.DetailedCollider);
             }

--- a/SnapBuilder/Patches/BuilderPatch.cs
+++ b/SnapBuilder/Patches/BuilderPatch.cs
@@ -28,6 +28,10 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
             {
                 ControlHint.Show(Lang.Hint.ToggleFineRotation, SnapBuilder.Config.FineRotation);
             }
+            if (__state && SnapBuilder.ColliderIsImprovable)
+            {
+                ControlHint.Show(Lang.Hint.DetailedCollider, SnapBuilder.Config.DetailedCollider);
+            }
         }
 #endif
 
@@ -51,6 +55,15 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
             {
                 rotation = SnapBuilder.CalculateRotation(ref Builder.additiveRotation, hit, Builder.forceUpright);
             }
+        }
+        #endregion
+
+        #region Builder.End
+        [HarmonyPatch(typeof(Builder), nameof(Builder.End))]
+        [HarmonyPostfix]
+        public static void EndPostfix()
+        {
+            SnapBuilder.RevertColliders();
         }
         #endregion
     }

--- a/SnapBuilder/Patches/BuilderToolPatch.cs
+++ b/SnapBuilder/Patches/BuilderToolPatch.cs
@@ -13,26 +13,29 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
         #region Builder.GetCustomUseText
         public struct GetCustomUseTextState
         {
-            public readonly bool WasPlacing;
-            public readonly bool WasPlacingRotatable;
-            public readonly bool WasSnappingEnabled;
-            public readonly bool WereHintsEnabled;
-            public readonly bool WasColliderImprovable;
+            public bool WasPlacing { get; }
+            public bool WasPlacingRotatable { get; }
+            public bool WasSnappingEnabled { get; }
+            public bool WereHintsEnabled { get; }
+            public bool WasColliderImprovable { get; }
+            public bool WasColliderImproved { get; }
 
             public GetCustomUseTextState(bool wasPlacing, bool wasPlacingRotatable, bool wasSnappingEnabled,
-                                         bool wereHintsEnabled, bool wasColliderImprovable)
+                                         bool wereHintsEnabled, bool wasColliderImprovable, bool wasColliderImproved)
             {
                 WasPlacing = wasPlacing;
                 WasPlacingRotatable = wasPlacingRotatable;
                 WasSnappingEnabled = wasSnappingEnabled;
                 WereHintsEnabled = wereHintsEnabled;
                 WasColliderImprovable = wasColliderImprovable;
+                WasColliderImproved = wasColliderImproved;
             }
         }
 
         private static bool wasSnappingEnabled = SnapBuilder.Config.Snapping.Enabled;
         private static bool wereHintsEnabled = SnapBuilder.Config.DisplayControlHints;
         private static bool wasColliderImprovable = SnapBuilder.IsColliderImprovable();
+        private static bool wasColliderImproved = SnapBuilder.IsColliderImproved();
         [HarmonyPatch(typeof(BuilderTool), nameof(BuilderTool.GetCustomUseText))]
         [HarmonyPrefix]
         public static void GetCustomUseTextPrefix(BuilderTool __instance, out GetCustomUseTextState __state)
@@ -41,11 +44,13 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
                                                 wasPlacingRotatable: __instance.wasPlacingRotatable,
                                                 wasSnappingEnabled: wasSnappingEnabled,
                                                 wereHintsEnabled: wereHintsEnabled,
-                                                wasColliderImprovable: wasColliderImprovable);
+                                                wasColliderImprovable: wasColliderImprovable,
+                                                wasColliderImproved: wasColliderImproved);
 
             wasSnappingEnabled = SnapBuilder.Config.Snapping.Enabled;
             wereHintsEnabled = SnapBuilder.Config.DisplayControlHints;
             wasColliderImprovable = SnapBuilder.IsColliderImprovable();
+            wasColliderImproved = SnapBuilder.IsColliderImproved();
         }
 
         [HarmonyPatch(typeof(BuilderTool), nameof(BuilderTool.GetCustomUseText))]
@@ -63,6 +68,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
                          || !__state.WasPlacing
                          || (SnapBuilder.Config.Snapping.Enabled != __state.WasSnappingEnabled)
                          || (SnapBuilder.IsColliderImprovable() != __state.WasColliderImprovable)
+                         || (SnapBuilder.IsColliderImproved() != __state.WasColliderImproved)
                          || (Builder.rotationEnabled != __state.WasPlacingRotatable)))
             {
                 __instance.UpdateCustomUseText();
@@ -87,9 +93,11 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
                     if (SnapBuilder.IsColliderImprovable()
                         && (!__state.WereHintsEnabled
                             || !__state.WasColliderImprovable
+                            || (SnapBuilder.IsColliderImproved() != __state.WasColliderImproved)
                             || (SnapBuilder.Config.Snapping.Enabled && !__state.WasSnappingEnabled)))
                     {
-                        lines[0] += $", {ControlHint.Get(Lang.Hint.DetailedCollider, SnapBuilder.Config.DetailedCollider)}";
+                        string hintId = SnapBuilder.IsColliderImproved() ? Lang.Hint.OriginalCollider : Lang.Hint.DetailedCollider;
+                        lines[0] += $", {ControlHint.Get(hintId, SnapBuilder.Config.DetailedCollider)}";
                     }
                 }
 

--- a/SnapBuilder/Patches/PlaceToolPatch.cs
+++ b/SnapBuilder/Patches/PlaceToolPatch.cs
@@ -22,7 +22,7 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.Patches
 
         [HarmonyPatch(typeof(PlaceTool), nameof(PlaceTool.CreateGhostModel))]
         [HarmonyPostfix]
-        public static void Postfix(PlaceTool __instance, bool __state)
+        public static void CreateGhostModelPostfix(PlaceTool __instance, bool __state)
         {
             if (__state && SnapBuilder.Config.DisplayControlHints && __instance.rotationEnabled)
             {

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -385,12 +385,12 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
                     });
                     if (primitive.GetComponent<Collider>() is Collider primitiveCollider)
                         primitiveCollider.enabled = false;
-                    primitive.GetComponent<Renderer>().material = Builder.ghostStructureMaterial;
+                    primitive.GetComponent<Renderer>().material = material;
                     primitive.transform.SetParent(gameObject.transform, false);
                     break;
             }
             gameObject.transform.SetParent(collider.transform, false);
-            gameObject.transform.localScale = collider.transform.localScale * scale;
+            gameObject.transform.localScale = collider.transform.lossyScale * scale;
             UWE.CoroutineHost.StartCoroutine(DestroyNextFrame(gameObject));
         }
 

--- a/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
+++ b/SnapBuilder/Straitjacket.Subnautica.Mods.SnapBuilder.csproj
@@ -93,6 +93,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Cache.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="ControlHint.cs" />
     <Compile Include="Lang.cs" />
@@ -108,11 +109,13 @@
     <None Include="mod_BELOWZERO.json" />
     <None Include="mod_SUBNAUTICA.json" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="..\Toggle\Toggle\Toggle.projitems" Label="Shared" />
   <Import Project="..\BepInEx.Logger\Logger\Logger.projitems" Label="Shared" />
   <Import Project="..\SMLHelper.Language\SMLHelper.Language\Language.projitems" Label="Shared" />
   <Import Project="..\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine\Straitjacket.ExtensionMethods.UnityEngine.projitems" Label="Shared" />
   <Import Project="..\Straitjacket.Math\Straitjacket.Math\Straitjacket.Math.projitems" Label="Shared" />
+  <Import Project="..\Straitjacket.SceneCache\Straitjacket.SceneCache\Straitjacket.SceneCache.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>echo f | xcopy "$(ProjectDir)mod_$(ConfigurationName).json" "$(TargetDir)$(SolutionName)\mod.json" /y


### PR DESCRIPTION
## Changes in this pull request
- In BZ, many of the rocks and other pieces of terrain have very roughly shaped colliders which are being used for placing items. This results in items which appear to be floating above the terrain, and isn't very pleasing. So, where possible, we instead use the mesh of the actual object.

- Also moves state objects into a cache that is reloaded whenever the scene unloads, which fixes a bug where those state objects would be pointing to de-initialized objects.