### PR TITLE
Fix cyclops forward rotation

### DIFF
--- a/SnapBuilder/ExtensionMethods/UnityEngineExtensionMethods.cs
+++ b/SnapBuilder/ExtensionMethods/UnityEngineExtensionMethods.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Straitjacket.Subnautica.Mods.SnapBuilder.ExtensionMethods
 {
@@ -67,7 +68,10 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.ExtensionMethods
         /// <returns></returns>
         public static Transform GetOptimalTransform(this RaycastHit hit) => Builder.GetSurfaceType(hit.normal) switch
         {
-            SurfaceType.Ground => hit.transform.parent ?? hit.transform,
+            SurfaceType.Ground when hit.transform.parent is Transform parent
+                                    && new float[] { 1, 0, 1 / Mathf.Sqrt(2) }
+                                           .Any(dot => Mathf.Approximately(dot, Mathf.Abs(Vector3.Dot(parent.forward, hit.transform.forward))))
+                                    => parent,
             _ => hit.transform
         };
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -112,11 +112,10 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
 
             // choose whether we should use the global forward, or the forward of the hitTransform
             Vector3 forward = hitTransform.forward.y != 0
-                              && !Player.main.IsInsideWalkable()
-                              && !Player.main.IsInSub()
-                              && hitTransform.GetComponent<BaseCell>() is null
-                                  ? Vector3.forward
-                                  : hitTransform.forward;
+                && !Player.main.IsInsideWalkable()
+                && hitTransform.GetComponent<BaseCell>() is null
+                    ? Vector3.forward
+                    : hitTransform.forward;
 
             // align the empty to face the chosen forward direction
             empty.transform.rotation = Quaternion.LookRotation(forward, Vector3.up);

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -112,10 +112,11 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
 
             // choose whether we should use the global forward, or the forward of the hitTransform
             Vector3 forward = hitTransform.forward.y != 0
-                && !Player.main.IsInsideWalkable()
-                && hitTransform.GetComponent<BaseCell>() is null
-                    ? Vector3.forward
-                    : hitTransform.forward;
+                              && !Player.main.IsInsideWalkable()
+                              && !Player.main.IsInSub()
+                              && hitTransform.GetComponent<BaseCell>() is null
+                                  ? Vector3.forward
+                                  : hitTransform.forward;
 
             // align the empty to face the chosen forward direction
             empty.transform.rotation = Quaternion.LookRotation(forward, Vector3.up);


### PR DESCRIPTION
Improved OptimalTransform algorithm, takes into account the difference in the angle between the parent and the original and treats them as good enough if the parent is at a 0,45,90,135,180 etc. degree rotation of the original before choosing the parent transform.

This eliminates a bug where in some instances, such as inside the cyclops, or in the [Habitat Platform](https://www.nexusmods.com/subnautica/mods/569) mod, we are choosing the parent for snapping/rotation when we should not, as the parent results in a poor alignment.