### PR TITLE
Fix habitat platform rotation

### DIFF
--- a/SnapBuilder/ExtensionMethods/UnityEngineExtensionMethods.cs
+++ b/SnapBuilder/ExtensionMethods/UnityEngineExtensionMethods.cs
@@ -69,9 +69,17 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.ExtensionMethods
         public static Transform GetOptimalTransform(this RaycastHit hit) => Builder.GetSurfaceType(hit.normal) switch
         {
             SurfaceType.Ground when hit.transform.parent is Transform parent
+                                    && parent.GetComponent<BaseCell>() is BaseCell => parent,
+            SurfaceType.Ground when hit.transform.parent is Transform parent
                                     && new float[] { 1, 0, 1 / Mathf.Sqrt(2) }
-                                           .Any(dot => Mathf.Approximately(dot, Mathf.Abs(Vector3.Dot(parent.forward, hit.transform.forward))))
+                                        .Any(dot => Mathf.Approximately(dot, Mathf.Abs(Vector3.Dot(parent.forward, hit.transform.forward))))
                                     => parent,
+            SurfaceType.Ground when Utils.GetEntityRoot(hit.transform.gameObject)?.transform is Transform root
+                                    && root.GetComponent<BaseCell>() is BaseCell => root,
+            SurfaceType.Ground when Utils.GetEntityRoot(hit.transform.gameObject)?.transform is Transform root
+                                    && new float[] { 1, 0, 1 / Mathf.Sqrt(2) }
+                                        .Any(dot => Mathf.Approximately(dot, Mathf.Abs(Vector3.Dot(root.forward, hit.transform.forward))))
+                                    => root,
             _ => hit.transform
         };
 

--- a/SnapBuilder/ExtensionMethods/UnityEngineExtensionMethods.cs
+++ b/SnapBuilder/ExtensionMethods/UnityEngineExtensionMethods.cs
@@ -68,18 +68,24 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder.ExtensionMethods
         /// <returns></returns>
         public static Transform GetOptimalTransform(this RaycastHit hit) => Builder.GetSurfaceType(hit.normal) switch
         {
-            SurfaceType.Ground when hit.transform.parent is Transform parent
-                                    && parent.GetComponent<BaseCell>() is BaseCell => parent,
-            SurfaceType.Ground when hit.transform.parent is Transform parent
-                                    && new float[] { 1, 0, 1 / Mathf.Sqrt(2) }
-                                        .Any(dot => Mathf.Approximately(dot, Mathf.Abs(Vector3.Dot(parent.forward, hit.transform.forward))))
-                                    => parent,
             SurfaceType.Ground when Utils.GetEntityRoot(hit.transform.gameObject)?.transform is Transform root
                                     && root.GetComponent<BaseCell>() is BaseCell => root,
+            SurfaceType.Ground when Utils.GetEntityRoot(hit.transform.gameObject)?.transform is Transform root
+                                    && root.GetComponent<Base>() is Base => hit.transform,
             SurfaceType.Ground when Utils.GetEntityRoot(hit.transform.gameObject)?.transform is Transform root
                                     && new float[] { 1, 0, 1 / Mathf.Sqrt(2) }
                                         .Any(dot => Mathf.Approximately(dot, Mathf.Abs(Vector3.Dot(root.forward, hit.transform.forward))))
                                     => root,
+
+            SurfaceType.Ground when hit.transform.parent is Transform parent
+                                    && parent.GetComponent<BaseCell>() is BaseCell => parent,
+            SurfaceType.Ground when hit.transform.parent is Transform parent
+                                    && parent.GetComponent<Base>() is Base => hit.transform,
+            SurfaceType.Ground when hit.transform.parent is Transform parent
+                                    && new float[] { 1, 0, 1 / Mathf.Sqrt(2) }
+                                        .Any(dot => Mathf.Approximately(dot, Mathf.Abs(Vector3.Dot(parent.forward, hit.transform.forward))))
+                                    => parent,
+
             _ => hit.transform
         };
 

--- a/SnapBuilder/SnapBuilder.cs
+++ b/SnapBuilder/SnapBuilder.cs
@@ -111,9 +111,10 @@ namespace Straitjacket.Subnautica.Mods.SnapBuilder
             empty.transform.position = hit.point; // Set the parent transform's position to our chosen position
 
             // choose whether we should use the global forward, or the forward of the hitTransform
-            Vector3 forward = hitTransform.forward.y != 0
+            Vector3 forward = !Mathf.Approximately(Mathf.Abs(Vector3.Dot(Vector3.up, hitTransform.up)), 1)
                 && !Player.main.IsInsideWalkable()
                 && hitTransform.GetComponent<BaseCell>() is null
+                && hitTransform.GetComponent<Base>() is null
                     ? Vector3.forward
                     : hitTransform.forward;
 


### PR DESCRIPTION
- Improved the selection of the optimal transform to work better when using Habitat Platform mod, and likely in other, as-yet-untested situations also.
- #46 Introduced a regression where the foundation rotation wasn't aligned properly. This also fixes that regression.